### PR TITLE
[Core] 로그인 토큰 저장을 위한 KeyChainService 및 LocalPersistanceManager 추가

### DIFF
--- a/Tooda/Sources/Core/AppInject.swift
+++ b/Tooda/Sources/Core/AppInject.swift
@@ -46,8 +46,10 @@ final class AppInject: AppInjectRegister, AppInjectResolve {
       )
     }
     
-    container.register(LocalPersistenceServiceType.self) { _ in
-      UserDefaultsService()
+    container.register(LocalPersistanceManagerType.self) { _ in
+      LocalPersistanceManager(
+        keyChainService: LocalPersistanceManager.KeyChainService(),
+        userDefaultService: LocalPersistanceManager.UserDefaultsService())
     }
   }
   

--- a/Tooda/Sources/Core/AppInject.swift
+++ b/Tooda/Sources/Core/AppInject.swift
@@ -46,7 +46,7 @@ final class AppInject: AppInjectRegister, AppInjectResolve {
       )
     }
     
-    container.register(UserDefaultsServiceType.self) { _ in
+    container.register(LocalPersistenceServiceType.self) { _ in
       UserDefaultsService()
     }
   }

--- a/Tooda/Sources/Core/AppInject.swift
+++ b/Tooda/Sources/Core/AppInject.swift
@@ -46,14 +46,37 @@ final class AppInject: AppInjectRegister, AppInjectResolve {
       )
     }
     
+    container.register(
+      LocalPersistenceServiceType.self,
+      name: LocalPersistenceType.keyChain.rawValue) { _ in
+      LocalPersistanceManager.KeyChainService()
+    }
+    
+    container.register(
+      LocalPersistenceServiceType.self,
+      name: LocalPersistenceType.userDefaults.rawValue) { _ in
+      LocalPersistanceManager.UserDefaultsService()
+    }
+    
     container.register(LocalPersistanceManagerType.self) { _ in
       LocalPersistanceManager(
-        keyChainService: LocalPersistanceManager.KeyChainService(),
-        userDefaultService: LocalPersistanceManager.UserDefaultsService())
+        keyChainService: self.resolve(
+          LocalPersistenceServiceType.self,
+          name: LocalPersistenceType.keyChain.rawValue
+        ),
+        userDefaultService: self.resolve(
+          LocalPersistenceServiceType.self,
+          name: LocalPersistenceType.userDefaults.rawValue
+        )
+      )
     }
   }
   
   func resolve<Object>(_ serviceType: Object.Type) -> Object {
     return container.resolve(serviceType)!
+  }
+  
+  func resolve<Object>(_ serviceType: Object.Type, name: String?) -> Object {
+    return container.resolve(serviceType, name: name)!
   }
 }

--- a/Tooda/Sources/Utils/KeyChainService.swift
+++ b/Tooda/Sources/Utils/KeyChainService.swift
@@ -9,48 +9,50 @@
 import Foundation
 import Security
 
-final class KeyChainService: LocalPersistenceServiceType {
-  func value<T>(forKey key: LocalPersistenceKey) -> T? {
-    let query = [
-      kSecClass as String: kSecClassGenericPassword,
-      kSecAttrAccount as String: key.rawValue,
-      kSecAttrService as String: key.rawValue,
-      kSecReturnData as String: kCFBooleanTrue,
-      kSecMatchLimit as String: kSecMatchLimitOne
-    ] as [String: Any?]
+extension LocalPersistanceManager {
+  final class KeyChainService: LocalPersistenceServiceType {
+    func value<T>(forKey key: LocalPersistenceKey) -> T? {
+      let query = [
+        kSecClass as String: kSecClassGenericPassword,
+        kSecAttrAccount as String: key.rawValue,
+        kSecAttrService as String: key.rawValue,
+        kSecReturnData as String: kCFBooleanTrue,
+        kSecMatchLimit as String: kSecMatchLimitOne
+      ] as [String: Any?]
 
-    var keyChainFetchedRef: AnyObject?
+      var keyChainFetchedRef: AnyObject?
 
-    let status: OSStatus = SecItemCopyMatching(query as CFDictionary, &keyChainFetchedRef)
+      let status: OSStatus = SecItemCopyMatching(query as CFDictionary, &keyChainFetchedRef)
 
-    return status == noErr ? keyChainFetchedRef as? T : nil
-  }
-  
-  func set<T>(value: T?, forKey key: LocalPersistenceKey) {
-    let query = [
-      kSecClass as String: kSecClassGenericPassword as String,
-      kSecAttrAccount as String: key.rawValue,
-      kSecAttrService as String: key.rawValue,
-      kSecValueData as String: value
-    ] as [String: Any?]
-
-    SecItemDelete(query as CFDictionary)
-    SecItemAdd(query as CFDictionary, nil)
-  }
-  
-  func objectValue<T>(forKey key: LocalPersistenceKey) -> T? where T: Decodable, T: Encodable {
-    let data: Data? = value(forKey: key)
-    let decoder = JSONDecoder()
-    guard let unwrappedData = data,
-          let decodedData = try? decoder.decode(T.self, from: unwrappedData) else { return nil }
-    return decodedData
-  }
-  
-  func setObject<T>(value: T?, forKey key: LocalPersistenceKey) where T: Decodable, T: Encodable {
-    let encoder = JSONEncoder()
-    guard let encodedData = try? encoder.encode(value) else {
-      return
+      return status == noErr ? keyChainFetchedRef as? T : nil
     }
-    set(value: encodedData, forKey: key)
+    
+    func set<T>(value: T?, forKey key: LocalPersistenceKey) {
+      let query = [
+        kSecClass as String: kSecClassGenericPassword as String,
+        kSecAttrAccount as String: key.rawValue,
+        kSecAttrService as String: key.rawValue,
+        kSecValueData as String: value
+      ] as [String: Any?]
+
+      SecItemDelete(query as CFDictionary)
+      SecItemAdd(query as CFDictionary, nil)
+    }
+    
+    func objectValue<T>(forKey key: LocalPersistenceKey) -> T? where T: Decodable, T: Encodable {
+      let data: Data? = value(forKey: key)
+      let decoder = JSONDecoder()
+      guard let unwrappedData = data,
+            let decodedData = try? decoder.decode(T.self, from: unwrappedData) else { return nil }
+      return decodedData
+    }
+    
+    func setObject<T>(value: T?, forKey key: LocalPersistenceKey) where T: Decodable, T: Encodable {
+      let encoder = JSONEncoder()
+      guard let encodedData = try? encoder.encode(value) else {
+        return
+      }
+      set(value: encodedData, forKey: key)
+    }
   }
 }

--- a/Tooda/Sources/Utils/KeyChainService.swift
+++ b/Tooda/Sources/Utils/KeyChainService.swift
@@ -1,0 +1,56 @@
+//
+//  KeyChainService.swift
+//  Tooda
+//
+//  Created by 황재욱 on 2021/07/10.
+//  Copyright © 2021 DTS. All rights reserved.
+//
+
+import Foundation
+import Security
+
+final class KeyChainService: LocalPersistenceServiceType {
+  func value<T>(forKey key: LocalPersistenceKey) -> T? {
+    let query = [
+      kSecClass as String: kSecClassGenericPassword,
+      kSecAttrAccount as String: key.rawValue,
+      kSecAttrService as String: key.rawValue,
+      kSecReturnData as String: kCFBooleanTrue,
+      kSecMatchLimit as String: kSecMatchLimitOne
+    ] as [String: Any?]
+
+    var keyChainFetchedRef: AnyObject?
+
+    let status: OSStatus = SecItemCopyMatching(query as CFDictionary, &keyChainFetchedRef)
+
+    return status == noErr ? keyChainFetchedRef as? T : nil
+  }
+  
+  func set<T>(value: T?, forKey key: LocalPersistenceKey) {
+    let query = [
+      kSecClass as String: kSecClassGenericPassword as String,
+      kSecAttrAccount as String: key.rawValue,
+      kSecAttrService as String: key.rawValue,
+      kSecValueData as String: value
+    ] as [String: Any?]
+
+    SecItemDelete(query as CFDictionary)
+    SecItemAdd(query as CFDictionary, nil)
+  }
+  
+  func objectValue<T>(forKey key: LocalPersistenceKey) -> T? where T: Decodable, T: Encodable {
+    let data: Data? = value(forKey: key)
+    let decoder = JSONDecoder()
+    guard let unwrappedData = data,
+          let decodedData = try? decoder.decode(T.self, from: unwrappedData) else { return nil }
+    return decodedData
+  }
+  
+  func setObject<T>(value: T?, forKey key: LocalPersistenceKey) where T: Decodable, T: Encodable {
+    let encoder = JSONEncoder()
+    guard let encodedData = try? encoder.encode(value) else {
+      return
+    }
+    set(value: encodedData, forKey: key)
+  }
+}

--- a/Tooda/Sources/Utils/LocalPersistanceManager.swift
+++ b/Tooda/Sources/Utils/LocalPersistanceManager.swift
@@ -1,0 +1,42 @@
+//
+//  LocalPersistanceManager.swift
+//  Tooda
+//
+//  Created by 황재욱 on 2021/07/10.
+//  Copyright © 2021 DTS. All rights reserved.
+//
+
+import Foundation
+
+enum LocalPersistanceManager {
+  case userDefaults
+  case keychain
+  
+  private static let keyChainService = KeyChainService()
+  private static let userDefaultService = UserDefaultsService()
+  
+  private var service: LocalPersistenceServiceType {
+    switch self {
+    case .userDefaults:
+      return LocalPersistanceManager.userDefaultService
+    case .keychain:
+      return LocalPersistanceManager.keyChainService
+    }
+  }
+  
+  func value<T>(forKey key: LocalPersistenceKey) -> T? {
+    service.value(forKey: key)
+  }
+  
+  func set<T>(value: T?, forKey key: LocalPersistenceKey) {
+    service.set(value: value, forKey: key)
+  }
+  
+  func objectValue<T: Codable>(forKey key: LocalPersistenceKey) -> T? {
+    service.objectValue(forKey: key)
+  }
+  
+  func setObject<T: Codable>(value: T?, forKey key: LocalPersistenceKey) {
+    service.setObject(value: value, forKey: key)
+  }
+}

--- a/Tooda/Sources/Utils/LocalPersistanceManager.swift
+++ b/Tooda/Sources/Utils/LocalPersistanceManager.swift
@@ -8,35 +8,59 @@
 
 import Foundation
 
-enum LocalPersistanceManager {
-  case userDefaults
-  case keychain
+protocol LocalPersistanceManagerType {
+  func value<T>(forKey key: LocalPersistenceKey) -> T?
+  func set<T>(value: T?, forKey key: LocalPersistenceKey)
   
-  private static let keyChainService = KeyChainService()
-  private static let userDefaultService = UserDefaultsService()
+  func objectValue<T: Codable>(forKey key: LocalPersistenceKey) -> T?
+  func setObject<T: Codable>(value: T?, forKey key: LocalPersistenceKey)
+}
+
+final class LocalPersistanceManager: LocalPersistanceManagerType {
+  private let keyChainService: LocalPersistenceServiceType
+  private let userDefaultService: LocalPersistenceServiceType
   
-  private var service: LocalPersistenceServiceType {
-    switch self {
-    case .userDefaults:
-      return LocalPersistanceManager.userDefaultService
-    case .keychain:
-      return LocalPersistanceManager.keyChainService
-    }
+  init(
+    keyChainService: LocalPersistenceServiceType,
+    userDefaultService: LocalPersistenceServiceType
+  ) {
+    self.keyChainService = keyChainService
+    self.userDefaultService = userDefaultService
   }
   
   func value<T>(forKey key: LocalPersistenceKey) -> T? {
-    service.value(forKey: key)
+    switch key {
+    case .appToken:
+      return keyChainService.value(forKey: key)
+    default:
+      return userDefaultService.value(forKey: key)
+    }
   }
   
   func set<T>(value: T?, forKey key: LocalPersistenceKey) {
-    service.set(value: value, forKey: key)
+    switch key {
+    case .appToken:
+      return keyChainService.set(value: value, forKey: key)
+    default:
+      return userDefaultService.set(value: value, forKey: key)
+    }
   }
   
   func objectValue<T: Codable>(forKey key: LocalPersistenceKey) -> T? {
-    service.objectValue(forKey: key)
+    switch key {
+    case .appToken:
+      return keyChainService.objectValue(forKey: key)
+    default:
+      return userDefaultService.objectValue(forKey: key)
+    }
   }
   
   func setObject<T: Codable>(value: T?, forKey key: LocalPersistenceKey) {
-    service.setObject(value: value, forKey: key)
+    switch key {
+    case .appToken:
+      return keyChainService.setObject(value: value, forKey: key)
+    default:
+      return userDefaultService.setObject(value: value, forKey: key)
+    }
   }
 }

--- a/Tooda/Sources/Utils/UserDefaultsService.swift
+++ b/Tooda/Sources/Utils/UserDefaultsService.swift
@@ -14,6 +14,11 @@ enum LocalPersistenceKey: String {
 	case appToken
 }
 
+enum LocalPersistenceType: String {
+  case keyChain
+  case userDefaults
+}
+
 protocol LocalPersistenceServiceType {
 	func value<T>(forKey key: LocalPersistenceKey) -> T?
 	func set<T>(value: T?, forKey key: LocalPersistenceKey)

--- a/Tooda/Sources/Utils/UserDefaultsService.swift
+++ b/Tooda/Sources/Utils/UserDefaultsService.swift
@@ -22,33 +22,35 @@ protocol LocalPersistenceServiceType {
 	func setObject<T: Codable>(value: T?, forKey key: LocalPersistenceKey)
 }
 
-final class UserDefaultsService: LocalPersistenceServiceType {
-	
-	private var defaults: UserDefaults {
-		return UserDefaults.standard
-	}
-	
-	func value<T>(forKey key: LocalPersistenceKey) -> T? {
-		return self.defaults.value(forKey: key.rawValue) as? T
-	}
-	
-	func set<T>(value: T?, forKey key: LocalPersistenceKey) {
-		self.defaults.set(value, forKey: key.rawValue)
-	}
-	
-	func setObject<T: Codable>(value: T?, forKey key: LocalPersistenceKey) {
-		let encoder = JSONEncoder()
-		guard let encodedData = try? encoder.encode(value) else {
-			return
-		}
-		self.defaults.set(encodedData, forKey: key.rawValue)
-	}
-	
-	func objectValue<T: Codable>(forKey key: LocalPersistenceKey) -> T? {
-		guard let storedValue = self.defaults.value(forKey: key.rawValue) as? Data else { return nil }
-		
-		let decoder = JSONDecoder()
-		guard let decodedData = try? decoder.decode(T.self, from: storedValue) else { return nil }
-		return decodedData
-	}
+extension LocalPersistanceManager {
+  final class UserDefaultsService: LocalPersistenceServiceType {
+    
+    private var defaults: UserDefaults {
+      return UserDefaults.standard
+    }
+    
+    func value<T>(forKey key: LocalPersistenceKey) -> T? {
+      return self.defaults.value(forKey: key.rawValue) as? T
+    }
+    
+    func set<T>(value: T?, forKey key: LocalPersistenceKey) {
+      self.defaults.set(value, forKey: key.rawValue)
+    }
+    
+    func setObject<T: Codable>(value: T?, forKey key: LocalPersistenceKey) {
+      let encoder = JSONEncoder()
+      guard let encodedData = try? encoder.encode(value) else {
+        return
+      }
+      self.defaults.set(encodedData, forKey: key.rawValue)
+    }
+    
+    func objectValue<T: Codable>(forKey key: LocalPersistenceKey) -> T? {
+      guard let storedValue = self.defaults.value(forKey: key.rawValue) as? Data else { return nil }
+      
+      let decoder = JSONDecoder()
+      guard let decodedData = try? decoder.decode(T.self, from: storedValue) else { return nil }
+      return decodedData
+    }
+  }
 }

--- a/Tooda/Sources/Utils/UserDefaultsService.swift
+++ b/Tooda/Sources/Utils/UserDefaultsService.swift
@@ -8,35 +8,35 @@
 
 import Foundation
 
-enum UserDefaultsKey: String {
+enum LocalPersistenceKey: String {
 	case firstLaunch
 	case searchHistory
 	case appToken
 }
 
-protocol UserDefaultsServiceType {
-	func value<T>(forKey key: UserDefaultsKey) -> T?
-	func set<T>(value: T?, forKey key: UserDefaultsKey)
+protocol LocalPersistenceServiceType {
+	func value<T>(forKey key: LocalPersistenceKey) -> T?
+	func set<T>(value: T?, forKey key: LocalPersistenceKey)
 	
-	func objectValue<T: Codable>(forKey key: UserDefaultsKey) -> T?
-	func setObject<T: Codable>(value: T?, forKey key: UserDefaultsKey)
+	func objectValue<T: Codable>(forKey key: LocalPersistenceKey) -> T?
+	func setObject<T: Codable>(value: T?, forKey key: LocalPersistenceKey)
 }
 
-final class UserDefaultsService: UserDefaultsServiceType {
+final class UserDefaultsService: LocalPersistenceServiceType {
 	
 	private var defaults: UserDefaults {
 		return UserDefaults.standard
 	}
 	
-	func value<T>(forKey key: UserDefaultsKey) -> T? {
+	func value<T>(forKey key: LocalPersistenceKey) -> T? {
 		return self.defaults.value(forKey: key.rawValue) as? T
 	}
 	
-	func set<T>(value: T?, forKey key: UserDefaultsKey) {
+	func set<T>(value: T?, forKey key: LocalPersistenceKey) {
 		self.defaults.set(value, forKey: key.rawValue)
 	}
 	
-	func setObject<T: Codable>(value: T?, forKey key: UserDefaultsKey) {
+	func setObject<T: Codable>(value: T?, forKey key: LocalPersistenceKey) {
 		let encoder = JSONEncoder()
 		guard let encodedData = try? encoder.encode(value) else {
 			return
@@ -44,7 +44,7 @@ final class UserDefaultsService: UserDefaultsServiceType {
 		self.defaults.set(encodedData, forKey: key.rawValue)
 	}
 	
-	func objectValue<T: Codable>(forKey key: UserDefaultsKey) -> T? {
+	func objectValue<T: Codable>(forKey key: LocalPersistenceKey) -> T? {
 		guard let storedValue = self.defaults.value(forKey: key.rawValue) as? Data else { return nil }
 		
 		let decoder = JSONDecoder()
@@ -52,4 +52,3 @@ final class UserDefaultsService: UserDefaultsServiceType {
 		return decodedData
 	}
 }
-


### PR DESCRIPTION
### 수정내역
- LocalPersistanceManager 추가
### Description
- 향후 Realm이 추가될 수도 있을 것 같아서 generic하게 쓸 수 있도록 protocol(LocalPersistenceServiceType)을 수정하고
LocalPersistanceManager를 통해 값을 set, fetch 할 수 있도록 통합했습니다

- Usage
```swift
// set
LocalPersistanceManager.keychain.set(value: token, forKey: .appToken)
LocalPersistanceManager.userDefaults.set(value: isFirstUser, forKey: .firstUser)

// fetch
LocalPersistanceManager.keychain.value(forKey: .appToken)
LocalPersistanceManager.userDefaults.value(forKey: .firstUser)
```
