### PR TITLE
[Util] AuthorizationService 추가

### DIFF
--- a/Tooda/Sources/Common/AuthorizationService.swift
+++ b/Tooda/Sources/Common/AuthorizationService.swift
@@ -1,0 +1,109 @@
+//
+//  AuthorizationService.swift
+//  Tooda
+//
+//  Created by lyine on 2021/05/24.
+//  Copyright © 2021 DTS. All rights reserved.
+//
+
+import Foundation
+import Photos
+
+import RxSwift
+import RxCocoa
+
+protocol AuthorizationServiceType {
+  var pushStatus: Observable<AuthorizationStatus> { get }
+  var requestPush: Observable<Bool> { get }
+  var photoLibrary: Observable<AuthorizationStatus> { get }
+}
+
+enum AuthorizationStatus {
+  case authorized
+  case denied
+  case notDetermined
+}
+
+class AuthorizationService: AuthorizationServiceType {
+  var pushStatus: Observable<AuthorizationStatus> {
+    return Observable.create { observer -> Disposable in
+      let pushCenter = UNUserNotificationCenter.current()
+      
+      pushCenter.getNotificationSettings { settings in
+        switch settings.authorizationStatus {
+          
+          case .authorized:
+            observer.onNext(AuthorizationStatus.authorized)
+            observer.onCompleted()
+            return
+          case .notDetermined:
+            observer.onNext(AuthorizationStatus.notDetermined)
+            observer.onCompleted()
+            return
+          default:
+            observer.onNext(AuthorizationStatus.denied)
+            observer.onCompleted()
+            return
+        }
+      }
+      
+      return Disposables.create()
+    }
+  }
+  
+  var requestPush: Observable<Bool> {
+    return Observable.create { observer -> Disposable in
+      let pushCenter = UNUserNotificationCenter.current()
+      let options: UNAuthorizationOptions = [.alert, .badge, .sound]
+      
+      pushCenter.requestAuthorization(options: options) { allowed, error in
+        if let error = error {
+          observer.onError(error)
+          return
+        }
+        observer.onNext(allowed)
+        observer.onCompleted()
+        return
+        
+      }
+      return Disposables.create()
+    }
+  }
+  
+  var photoLibrary: Observable<AuthorizationStatus> {
+    return Observable.create { observer -> Disposable in
+      
+      if #available(iOS 14, *) {
+        PHPhotoLibrary.requestAuthorization(for: .addOnly, handler: { status in
+          switch status {
+            case .authorized, .limited:
+              observer.onNext(.authorized)
+              observer.onCompleted()
+            case .restricted, .denied:
+              observer.onNext(.denied)
+              observer.onCompleted()
+            default:
+              observer.onNext(.notDetermined)
+              observer.onCompleted()
+          }
+        })
+      } else {
+        PHPhotoLibrary.requestAuthorization({ status in
+          switch status {
+            case .authorized:
+              observer.onNext(.authorized)
+              observer.onCompleted()
+            case .restricted, .denied:
+              observer.onNext(.denied)
+              observer.onCompleted()
+            default:
+              observer.onNext(.notDetermined)
+              observer.onCompleted()
+          }
+        })
+      }
+      
+      return Disposables.create()
+    }
+  }
+}

--- a/Tooda/Sources/Common/RxAuthorization.swift
+++ b/Tooda/Sources/Common/RxAuthorization.swift
@@ -1,5 +1,5 @@
 //
-//  AuthorizationService.swift
+//  RxAuthorization.swift
 //  Tooda
 //
 //  Created by lyine on 2021/05/24.
@@ -12,7 +12,7 @@ import Photos
 import RxSwift
 import RxCocoa
 
-protocol AuthorizationServiceType {
+protocol AppAuthorizationType {
   var pushStatus: Observable<AuthorizationStatus> { get }
   var requestPush: Observable<Bool> { get }
   var photoLibrary: Observable<AuthorizationStatus> { get }
@@ -24,7 +24,7 @@ enum AuthorizationStatus {
   case notDetermined
 }
 
-class AuthorizationService: AuthorizationServiceType {
+class RxAuthorization: AppAuthorizationType {
   var pushStatus: Observable<AuthorizationStatus> {
     return Observable.create { observer -> Disposable in
       let pushCenter = UNUserNotificationCenter.current()

--- a/Tooda/Sources/Core/AppInject.swift
+++ b/Tooda/Sources/Core/AppInject.swift
@@ -51,19 +51,12 @@ final class AppInject: AppInjectRegister, AppInjectResolve {
     }
     
     
-    // TODO: git merge 이후 메소드 분리
-    addAuthorizationService()
+    container.register(AuthorizationServiceType.self) { _ in
+      AuthorizationService()
+    }
   }
   
   func resolve<Object>(_ serviceType: Object.Type) -> Object {
     return container.resolve(serviceType)!
-  }
-}
-
-extension AppInject {
-  func addAuthorizationService() {
-    container.register(AuthorizationServiceType.self) { _ in
-      AuthorizationService()
-    }
   }
 }

--- a/Tooda/Sources/Core/AppInject.swift
+++ b/Tooda/Sources/Core/AppInject.swift
@@ -51,8 +51,8 @@ final class AppInject: AppInjectRegister, AppInjectResolve {
     }
     
     
-    container.register(AuthorizationServiceType.self) { _ in
-      AuthorizationService()
+    container.register(AppAuthorizationType.self) { _ in
+      RxAuthorization()
     }
   }
   

--- a/Tooda/Sources/Core/AppInject.swift
+++ b/Tooda/Sources/Core/AppInject.swift
@@ -49,9 +49,21 @@ final class AppInject: AppInjectRegister, AppInjectResolve {
     container.register(UserDefaultsServiceType.self) { _ in
       UserDefaultsService()
     }
+    
+    
+    // TODO: git merge 이후 메소드 분리
+    addAuthorizationService()
   }
   
   func resolve<Object>(_ serviceType: Object.Type) -> Object {
     return container.resolve(serviceType)!
+  }
+}
+
+extension AppInject {
+  func addAuthorizationService() {
+    container.register(AuthorizationServiceType.self) { _ in
+      AuthorizationService()
+    }
   }
 }

--- a/Tooda/Sources/SupportFiles/Info.plist
+++ b/Tooda/Sources/SupportFiles/Info.plist
@@ -2,10 +2,12 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>&apos;tooda&apos;가 사진을 게시글에 첨부하기 위해 사진 라이브러리에 접근하도록 허용합니다.</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>&apos;tooda&apos;가 사진을 게시글에 첨부하기 위해 사진 라이브러리에 접근하도록 허용합니다.</string>
 	<key>CFBundleDisplayName</key>
 	<string>$(APP_NAME)</string>
-	<key>MyValue</key>
-	<string>$(MY_VALUE)</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>


### PR DESCRIPTION
### 수정내역
- 앱내에서 사용할 권한을 관리하는 Service를 추가하였습니다.
### Description
- AuthorizationService는 푸시알림, 사진권한의 상태를 Observable로 구독할 수 있습니다.
- 사진 권한을 요청할 때 필요한 문구를 info.plist에 추가하였습니다.

사용방법
```
let service = self.dependency.authorizationService
    
    return service.photoLibrary.flatMap { [weak self] status -> Observable<Mutation> in
      switch status {
        case .authorized:
          guard let mutation = self?.didSelectedItem(indexPath) else { return .empty() }
          return mutation
        default:
          return .just(Mutation.requestPermissionMessage("테스트"))
      }
    }
```