### PR TITLE
[Entity] 노트 관련 Entities 변경

### DIFF
--- a/Tooda/Sources/Entities/Note/Note.swift
+++ b/Tooda/Sources/Entities/Note/Note.swift
@@ -10,7 +10,7 @@ import Foundation
 
 // TODO:재봉님께 양식 전달 받은 이후에 값 변경
 enum Comment: String, Codable {
-	case smile, sad
+	case SAD, OMG, ANGRY, THINKING, CHICKEN, PENCIL
 }
 
 struct Note: Codable {
@@ -28,12 +28,12 @@ struct Note: Codable {
 		case id = "id"
 		case title = "title"
 		case content = "content"
-		case createdAt = "created_at"
-		case updatedAt = "updated_at"
-		case comment = "comment"
-		case noteStocks = "diary_stocks"
-		case noteLinks = "diary_links"
-		case noteImages = "diary_images"
+		case comment = "sticker"
+		case noteStocks = "stocks"
+		case noteLinks = "links"
+		case noteImages = "images"
+		case createdAt = "createdAt"
+		case updatedAt = "updatedAt"
 	}
 	
 	init(from decoder: Decoder) throws {

--- a/Tooda/Sources/Entities/Note/Note.swift
+++ b/Tooda/Sources/Entities/Note/Note.swift
@@ -8,7 +8,6 @@
 
 import Foundation
 
-// TODO:재봉님께 양식 전달 받은 이후에 값 변경
 enum Comment: String, Codable {
 	case SAD, OMG, ANGRY, THINKING, CHICKEN, PENCIL
 }

--- a/Tooda/Sources/Entities/Note/NoteLink.swift
+++ b/Tooda/Sources/Entities/Note/NoteLink.swift
@@ -13,25 +13,31 @@ struct NoteLink: Codable {
 	var title: String
 	var description: String?
 	var siteName: String?
-	var url: String
+	var url: String?
 	var imageURL: String?
+	var createdAt: String?
+	var updatedAt: String?
 	
 	private enum CodingKeys: String, CodingKey {
 		case id = "id"
-		case title = "title"
-		case description = "description"
-		case siteName = "site_name"
-		case url = "url"
-		case imageURL = "image"
+		case title = "ogTitle"
+		case description = "ogDescription"
+		case siteName = "ogSiteName"
+		case url = "ogUrl"
+		case imageURL = "ogImage"
+		case createdAt = "createdAt"
+		case updatedAt = "updatedAt"
 	}
 	
 	init(from decoder: Decoder) throws {
 		let values = try decoder.container(keyedBy: CodingKeys.self)
 		id = try values.decode(Int.self, forKey: .id)
 		title = try values.decode(String.self, forKey: .title)
-		description = try values.decode(String.self, forKey: .description)
-		siteName = try values.decode(String.self, forKey: .siteName)
-		url = try values.decode(String.self, forKey: .url)
-		imageURL = try values.decode(String.self, forKey: .imageURL)
+		description = try values.decode(String?.self, forKey: .description)
+		siteName = try values.decode(String?.self, forKey: .siteName)
+		url = try values.decode(String?.self, forKey: .url)
+		imageURL = try values.decode(String?.self, forKey: .imageURL)
+		createdAt = try values.decode(String?.self, forKey: .createdAt)
+		updatedAt = try values.decode(String?.self, forKey: .updatedAt)
 	}
 }

--- a/Tooda/Sources/Entities/Note/NoteStock.swift
+++ b/Tooda/Sources/Entities/Note/NoteStock.swift
@@ -9,9 +9,9 @@
 import Foundation
 
 enum StockChangeState: String, Codable {
-	case rise
-	case even
-	case fall
+	case RISE
+	case EVEN
+	case FALL
 }
 
 struct NoteStock: Codable {
@@ -19,19 +19,4 @@ struct NoteStock: Codable {
 	var name: String
 	var change: StockChangeState?
 	var changeRate: Float?
-	
-	private enum CodingKeys: String, CodingKey {
-		case id = "id"
-		case name = "name"
-		case change = "change"
-		case changeRate = "change_rate"
-	}
-	
-	init(from decoder: Decoder) throws {
-		let values = try decoder.container(keyedBy: CodingKeys.self)
-		id = try values.decode(Int.self, forKey: .id)
-		name = try values.decode(String.self, forKey: .name)
-		change = try values.decode(StockChangeState.self, forKey: .change)
-		changeRate = try values.decode(Float.self, forKey: .changeRate)
-	}
 }


### PR DESCRIPTION
### 수정내역
- 노트 등록, 조회를 위한 Entities를 서버 스펙에 맞게 변경하였습니다.
### Description
- Note, NoteLink의 codingKey를 서버 요구사항에 맞게 변경했어요.
- StockChangeState의 case 명을 대문자로 변경했어요.
