### PR TITLE
ViewDidLoad, Reactor Bind 함수 call 순서 이슈 수정

### DIFF
--- a/Tooda/Sources/Base/BaseViewController.swift
+++ b/Tooda/Sources/Base/BaseViewController.swift
@@ -21,8 +21,8 @@ class BaseViewController<T: Reactor>: UIViewController, View {
   
   override func viewDidLoad() {
     super.viewDidLoad()
-    self.configureUI()
-    self.configureConstraints()
+    configureUI()
+    configureConstraints()
   }
   
   required init?(coder: NSCoder) {

--- a/Tooda/Sources/Base/BaseViewController.swift
+++ b/Tooda/Sources/Base/BaseViewController.swift
@@ -17,6 +17,10 @@ class BaseViewController<T: Reactor>: UIViewController, View {
   
   init() {
     super.init(nibName: nil, bundle: nil)
+  }
+  
+  override func viewDidLoad() {
+    super.viewDidLoad()
     self.configureUI()
     self.configureConstraints()
   }

--- a/Tooda/Sources/Common/Extensions/Date+Extension.swift
+++ b/Tooda/Sources/Common/Extensions/Date+Extension.swift
@@ -43,7 +43,7 @@ extension Date {
     dateFormatter.dateFormat = type.rawValue
     dateFormatter.locale = Locale.current
     dateFormatter.timeZone = TimeZone.current
-    return formatter.string(from: self)
+    return dateFormatter.string(from: self)
   }
 
   func component(_ component: Calendar.Component) -> Int {


### PR DESCRIPTION
### ScreenShot

- 이슈 확인을 위해 함수 call print
<img width="870" alt="스크린샷 2021-07-31 오후 6 35 09" src="https://user-images.githubusercontent.com/31857308/127735871-be320a08-29dc-4876-93fa-1fa2225b77b3.png">

| Before | After |
|----|----|
| <img width="619" alt="스크린샷 2021-07-31 오후 6 38 28" src="https://user-images.githubusercontent.com/31857308/127736011-28533bec-4601-4766-88fe-1fe1bbd8ee21.png"> | <img width="617" alt="스크린샷 2021-07-31 오후 6 35 14" src="https://user-images.githubusercontent.com/31857308/127736016-d66e2456-93a0-4114-ac50-53ae4532853d.png"> |


### 수정내역
- 기존에는 reactor bind가 viewDidLoad 이후 불려서 rx.viewDidLoad를 사용할 수 없었음
- 명확한 원인을 파악한 것은 아니지만 init에서 다른 작업이 이뤄지면서 aync로 viewDidLoad가 먼저 불리는게 아닐까 가설을 세우고
init에서 다른 함수 call을 viewDidLoad로 이동
```swift
override func viewDidLoad() {
    super.viewDidLoad()
    configureUI()
    configureConstraints()
  }
```
