### PR TITLE
[Util] 빌드 에러 수정

### DIFF
--- a/Tooda/Sources/Common/Extensions/Date+Extension.swift
+++ b/Tooda/Sources/Common/Extensions/Date+Extension.swift
@@ -43,7 +43,7 @@ extension Date {
     dateFormatter.dateFormat = type.rawValue
     dateFormatter.locale = Locale.current
     dateFormatter.timeZone = TimeZone.current
-    return formatter.string(from: self)
+    return dateFormatter.string(from: self)
   }
 
   func component(_ component: Calendar.Component) -> Int {


### PR DESCRIPTION
### 수정내역
- Date+Extension 에서 string(_ type: DateFormatType = .base)의 return 되는 변수를 변경
### Description
- string 메소드에서 Return에 dateFormatter이 아닌 formatter를 사용하고 있어 빌드 에러가 발생하는 문제를 수정했어요.
