### PR TITLE
[Core] Rename Typo to Font

### DIFF
--- a/Tooda/Sources/Scenes/Home/Cells/NotebookCell.swift
+++ b/Tooda/Sources/Scenes/Home/Cells/NotebookCell.swift
@@ -14,7 +14,7 @@ class NotebookCell: UICollectionViewCell {
 
   // MARK: Constants
 
-  private enum Typo {
+  private enum Font {
     static let titleMonth = TextStyle.subTitleBold(color: .white)
     static let title = TextStyle.subTitle(color: .white)
     static let historyDate = TextStyle.caption(color: .white)
@@ -94,18 +94,18 @@ class NotebookCell: UICollectionViewCell {
 
   func configure(viewModel: ViewModel) {
     self.viewModel = viewModel
-    print(Text.monthTitle.styled(with: Typo.titleMonth).replace(key: "month", value: viewModel.month).string)
+    print(Text.monthTitle.styled(with: Font.titleMonth).replace(key: "month", value: viewModel.month).string)
     self.titleLabel.attributedText = NSAttributedString.composed(
       of: [
-        Text.monthTitle.styled(with: Typo.titleMonth).replace(key: "month", value: viewModel.month),
-        Text.titleSuffix.styled(with: Typo.title)
+        Text.monthTitle.styled(with: Font.titleMonth).replace(key: "month", value: viewModel.month),
+        Text.titleSuffix.styled(with: Font.title)
       ]
     )
     guard let historyDate = viewModel.historyDate else {
-      self.historyDateLabel.attributedText = Text.emptyHistoryDate.styled(with: Typo.emptyHistoryDate)
+      self.historyDateLabel.attributedText = Text.emptyHistoryDate.styled(with: Font.emptyHistoryDate)
       return
     }
-    self.historyDateLabel.attributedText = Text.historyDate.styled(with: Typo.historyDate)
+    self.historyDateLabel.attributedText = Text.historyDate.styled(with: Font.historyDate)
       .replace(key: "day", value: historyDate)
   }
 

--- a/Tooda/Sources/Scenes/Home/HomeViewController.swift
+++ b/Tooda/Sources/Scenes/Home/HomeViewController.swift
@@ -17,7 +17,7 @@ final class HomeViewController: BaseViewController<HomeReactor> {
 
   // MARK: Constants
 
-  private enum Typo {
+  private enum Font {
     static let monthTitle = TextStyle.headlineBold(color: .gray1)
     static let noteCount = TextStyle.bodyBold(color: .gray2)
     static let noteCountSuffix = TextStyle.body(color: .gray2)
@@ -51,12 +51,12 @@ final class HomeViewController: BaseViewController<HomeReactor> {
       UIImage(type: .iconDownGray),
       for: .normal
     )
-    $0.setAttributedTitle("wrewr".styled(with: Typo.monthTitle), for: .normal)
+    $0.setAttributedTitle("wrewr".styled(with: Font.monthTitle), for: .normal)
   }
 
   private let noteCountLabel = UILabel().then {
     $0.numberOfLines = 1
-    $0.attributedText = "3".styled(with: Typo.noteCount) + "werwerwe".styled(with: Typo.noteCountSuffix)
+    $0.attributedText = "3".styled(with: Font.noteCount) + "werwerwe".styled(with: Font.noteCountSuffix)
   }
 
   private let notebookCollectionView = UICollectionView(


### PR DESCRIPTION
### 수정내역
- Typo -> Font Renaming

### Description
<img width="625" alt="스크린샷 2021-09-01 오후 10 54 52" src="https://user-images.githubusercontent.com/31857308/131684176-83f33c44-a06a-4c61-9cde-d5edfd7ac274.png">
- 명확한 의미 전달을 위해 타이핑 실수라는 뜻의 Typo대신 Font 네임 사용으로 수정

