### PR TITLE
[UI] 노트 등록 화면에서 이미지 셀을 추가했어요.

### DIFF
--- a/Tooda/Sources/Core/AppFactory.swift
+++ b/Tooda/Sources/Core/AppFactory.swift
@@ -37,11 +37,12 @@ final class AppFactory: AppFactoryType {
         )
         return HomeViewController(reactor: reactor)
       case .createNote:
-        let reactor = CreateNoteViewReactor(createDiarySectionFactory: createDiarySectionFactory,
-                                             dependency: .init(
-                                              service: self.dependency.appInject.resolve(NetworkingProtocol.self),
-                                              coordinator: self.dependency.appInject.resolve(AppCoordinatorType.self)
-                                             ))
+        let reactor = CreateNoteViewReactor(dependency: .init(
+          service: self.dependency.appInject.resolve(NetworkingProtocol.self),
+          coordinator: self.dependency.appInject.resolve(AppCoordinatorType.self),
+          authorization: self.dependency.appInject.resolve(AppAuthorizationType.self),
+          createDiarySectionFactory: createDiarySectionFactory)
+        )
         return CreateNoteViewController(reactor: reactor)
     }
   }

--- a/Tooda/Sources/Entities/Note/NoteImage.swift
+++ b/Tooda/Sources/Entities/Note/NoteImage.swift
@@ -27,9 +27,9 @@ struct NoteImage: Codable {
 extension NoteImage {
   init() {
     self.id = 0
-    self.imageURL = "ccc"
+    self.imageURL = ""
   }
-  
+
   init(id: Int, url: String) {
     self.id = id
     self.imageURL = url

--- a/Tooda/Sources/Entities/Note/NoteImage.swift
+++ b/Tooda/Sources/Entities/Note/NoteImage.swift
@@ -23,3 +23,15 @@ struct NoteImage: Codable {
 		imageURL = try values.decode(String.self, forKey: .imageURL)
 	}
 }
+
+extension NoteImage {
+  init() {
+    self.id = 0
+    self.imageURL = "ccc"
+  }
+  
+  init(id: Int, url: String) {
+    self.id = id
+    self.imageURL = url
+  }
+}

--- a/Tooda/Sources/Scenes/CreateNote/Cells/EmptyNoteImageItemCell.swift
+++ b/Tooda/Sources/Scenes/CreateNote/Cells/EmptyNoteImageItemCell.swift
@@ -1,0 +1,50 @@
+//
+//  EmptyNoteImageItemCell.swift
+//  Tooda
+//
+//  Created by lyine on 2021/05/24.
+//  Copyright © 2021 DTS. All rights reserved.
+//
+
+import UIKit
+
+import ReactorKit
+
+import SnapKit
+
+class EmptyNoteImageItemCell: BaseCollectionViewCell, View {
+  typealias Reactor = EmptyNoteImageItemCellReactor
+  
+  var disposeBag: DisposeBag = DisposeBag()
+  
+  let containerView = UIView().then {
+    $0.backgroundColor = UIColor(type: .gray3)
+    $0.layer.cornerRadius = 8.0
+    $0.layer.masksToBounds = true
+  }
+  
+  func configure(reactor: Reactor) {
+    super.configure()
+    self.reactor = reactor
+  }
+  
+  func bind(reactor: Reactor) {
+    
+  }
+  
+  override func configureUI() {
+    super.configureUI()
+    
+    [containerView].forEach {
+      self.contentView.addSubview($0)
+    }
+  }
+  
+  override func setupConstraints() {
+    super.setupConstraints()
+    
+    containerView.snp.makeConstraints {
+      $0.edges.equalToSuperview()
+    }
+  }
+}

--- a/Tooda/Sources/Scenes/CreateNote/Cells/EmptyNoteImageItemCell.swift
+++ b/Tooda/Sources/Scenes/CreateNote/Cells/EmptyNoteImageItemCell.swift
@@ -32,6 +32,13 @@ class EmptyNoteImageItemCell: BaseCollectionViewCell, View {
     
   }
   
+  // MARK: Cell Life Cycle
+  
+  override func prepareForReuse() {
+    super.prepareForReuse()
+    disposeBag = DisposeBag()
+  }
+  
   override func configureUI() {
     super.configureUI()
     

--- a/Tooda/Sources/Scenes/CreateNote/Cells/EmptyNoteLinkCell.swift
+++ b/Tooda/Sources/Scenes/CreateNote/Cells/EmptyNoteLinkCell.swift
@@ -15,6 +15,12 @@ class EmptyNoteLinkCell: BaseTableViewCell, View {
   typealias Reactor = EmptyNoteLinkCellReactor
 
   var disposeBag: DisposeBag = DisposeBag()
+  
+  // MARK: Cell Life Cycle
+  
+  override func prepareForReuse() {
+    super.prepareForReuse()
+  }
 
   func bind(reactor: Reactor) {
 

--- a/Tooda/Sources/Scenes/CreateNote/Cells/EmptyNoteStockCell.swift
+++ b/Tooda/Sources/Scenes/CreateNote/Cells/EmptyNoteStockCell.swift
@@ -44,6 +44,13 @@ class EmptyNoteStockCell: BaseTableViewCell, View {
 
   }
   
+  // MARK: Cell Life Cycle
+  
+  override func prepareForReuse() {
+    super.prepareForReuse()
+    disposeBag = DisposeBag()
+  }
+  
   override func configureUI() {
     super.configureUI()
     

--- a/Tooda/Sources/Scenes/CreateNote/Cells/NoteContentCell.swift
+++ b/Tooda/Sources/Scenes/CreateNote/Cells/NoteContentCell.swift
@@ -50,6 +50,13 @@ class NoteContentCell: BaseTableViewCell, View {
     super.configure()
     self.reactor = reactor
   }
+  
+  // MARK: Cell Life Cycle
+  
+  override func prepareForReuse() {
+    super.prepareForReuse()
+    disposeBag = DisposeBag()
+  }
 
   override func configureUI() {
     super.configureUI()

--- a/Tooda/Sources/Scenes/CreateNote/Cells/NoteImageCell.swift
+++ b/Tooda/Sources/Scenes/CreateNote/Cells/NoteImageCell.swift
@@ -9,14 +9,131 @@
 import UIKit
 
 import ReactorKit
+import RxDataSources
 import SnapKit
 
 class NoteImageCell: BaseTableViewCell, View {
   typealias Reactor = NoteImageCellReactor
+  typealias Section = RxCollectionViewSectionedReloadDataSource<NoteImageSection>
+  
+  private enum Constants {
+    static let baseItemValue: CGFloat = 94
+  }
 
   var disposeBag: DisposeBag = DisposeBag()
+  
+  lazy var dataSource: Section = Section(configureCell: { _, collectionView, indexPath, item -> UICollectionViewCell in
+    switch item {
+      case .empty(let reactor):
+        let cell = collectionView.dequeue(EmptyNoteImageItemCell.self, indexPath: indexPath)
+        cell.configure(reactor: reactor)
+        return cell
+      case .item(let reactor):
+        let cell = collectionView.dequeue(NoteImageItemCell.self, indexPath: indexPath)
+        cell.configure(reactor: reactor)
+        return cell
+    }
+  })
+  
+  let flowLayout: UICollectionViewFlowLayout = UICollectionViewFlowLayout()
+  
+  lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: self.flowLayout).then {
+    $0.backgroundColor = .white
+    self.flowLayout.scrollDirection = .horizontal
+    self.flowLayout.minimumLineSpacing = 10
+    self.flowLayout.minimumInteritemSpacing = 10
+    self.flowLayout.sectionHeadersPinToVisibleBounds = true
+    
+    $0.alwaysBounceVertical = false
+    $0.showsVerticalScrollIndicator = false
+    $0.showsHorizontalScrollIndicator = false
+    
+    // cell
+    $0.register(EmptyNoteImageItemCell.self)
+    $0.register(NoteImageItemCell.self)
+    
+    self.flowLayout.itemSize = CGSize(width: Constants.baseItemValue, height: Constants.baseItemValue)
+  }
+  
+  func configure(reactor: Reactor) {
+    super.configure()
+    self.reactor = reactor
+  }
+  
+  override func configureUI() {
+    super.configureUI()
+    
+    [collectionView].forEach {
+      self.contentView.addSubview($0)
+    }
+  }
+  
+  override func setupConstraints() {
+    super.setupConstraints()
+    
+    collectionView.snp.makeConstraints {
+      $0.top.equalToSuperview().offset(10)
+      $0.left.right.bottom.equalToSuperview()
+      $0.height.equalTo(Constants.baseItemValue)
+    }
+  }
 
   func bind(reactor: Reactor) {
+    
+    Observable.just(())
+      .map { _ in Reactor.Action.initiailizeSection }
+      .bind(to: reactor.action)
+      .disposed(by: self.disposeBag)
+    
+    collectionView.rx.itemSelected
+      .map { Reactor.Action.didSelectedItem($0) }
+      .bind(to: reactor.action)
+      .disposed(by: self.disposeBag)
+    
+    reactor.state
+      .map { $0.sections }
+      .bind(to: collectionView.rx.items(dataSource: dataSource))
+      .disposed(by: self.disposeBag)
+    
+    reactor.state
+      .map { $0.requestPermissionMessage }
+      .filter { $0 != nil }
+      .subscribe(onNext: { [weak self] in
+        self?.showAlertAndOpenAppSetting(message: $0)
+      })
+      .disposed(by: self.disposeBag)
+    
+    reactor.state
+      .map { $0.showAlertMessage }
+      .filter { $0 != nil }
+      .subscribe(onNext: { [weak self] in
+        self?.showAlert(message: $0)
+      })
+      .disposed(by: self.disposeBag)
+    
+    self.collectionView.rx.setDelegate(self).disposed(by: self.disposeBag)
+  }
+}
 
+// MARK: UICollectionViewDelegate
+
+extension NoteImageCell: UICollectionViewDelegateFlowLayout {
+  func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
+    return .init(top: 0, left: 0, bottom: 0, right: 10)
+  }
+}
+
+extension NoteImageCell {
+  func showAlert(message: String?) {
+    print(message)
+  }
+  
+  func showAlertAndOpenAppSetting(message: String?) {
+    print(message)
+  }
+  
+  private func openAppSettingMenu() {
+    guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
+    UIApplication.shared.open(url, options: [:], completionHandler: nil)
   }
 }

--- a/Tooda/Sources/Scenes/CreateNote/Cells/NoteImageCell.swift
+++ b/Tooda/Sources/Scenes/CreateNote/Cells/NoteImageCell.swift
@@ -117,6 +117,7 @@ class NoteImageCell: BaseTableViewCell, View {
 
 // MARK: UICollectionViewDelegate
 
+// TODO: Master 병합 후 Extension 변경 처리
 extension NoteImageCell: UICollectionViewDelegateFlowLayout {
   func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
     return .init(top: 0, left: 0, bottom: 0, right: 10)

--- a/Tooda/Sources/Scenes/CreateNote/Cells/NoteImageCell.swift
+++ b/Tooda/Sources/Scenes/CreateNote/Cells/NoteImageCell.swift
@@ -60,6 +60,13 @@ class NoteImageCell: BaseTableViewCell, View {
     self.reactor = reactor
   }
   
+  // MARK: Cell Life Cycle
+  
+  override func prepareForReuse() {
+    super.prepareForReuse()
+    disposeBag = DisposeBag()
+  }
+  
   override func configureUI() {
     super.configureUI()
     

--- a/Tooda/Sources/Scenes/CreateNote/Cells/NoteImageCell.swift
+++ b/Tooda/Sources/Scenes/CreateNote/Cells/NoteImageCell.swift
@@ -22,7 +22,7 @@ class NoteImageCell: BaseTableViewCell, View {
 
   var disposeBag: DisposeBag = DisposeBag()
   
-  lazy var dataSource: Section = Section(configureCell: { _, collectionView, indexPath, item -> UICollectionViewCell in
+  private lazy var dataSource: Section = Section(configureCell: { _, collectionView, indexPath, item -> UICollectionViewCell in
     switch item {
       case .empty(let reactor):
         let cell = collectionView.dequeue(EmptyNoteImageItemCell.self, indexPath: indexPath)
@@ -35,9 +35,10 @@ class NoteImageCell: BaseTableViewCell, View {
     }
   })
   
-  let flowLayout: UICollectionViewFlowLayout = UICollectionViewFlowLayout()
+  private let flowLayout: UICollectionViewFlowLayout = UICollectionViewFlowLayout()
   
-  lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: self.flowLayout).then {
+  private lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: self.flowLayout).then {
+    
     $0.backgroundColor = .white
     self.flowLayout.scrollDirection = .horizontal
     self.flowLayout.minimumLineSpacing = 10

--- a/Tooda/Sources/Scenes/CreateNote/Cells/NoteImageItemCell.swift
+++ b/Tooda/Sources/Scenes/CreateNote/Cells/NoteImageItemCell.swift
@@ -34,6 +34,13 @@ class NoteImageItemCell: BaseCollectionViewCell, View {
     
   }
   
+  // MARK: Cell Life Cycle
+  
+  override func prepareForReuse() {
+    super.prepareForReuse()
+    disposeBag = DisposeBag()
+  }
+  
   override func configureUI() {
     super.configureUI()
     

--- a/Tooda/Sources/Scenes/CreateNote/Cells/NoteImageItemCell.swift
+++ b/Tooda/Sources/Scenes/CreateNote/Cells/NoteImageItemCell.swift
@@ -1,0 +1,52 @@
+//
+//  NoteImageItemCell.swift
+//  Tooda
+//
+//  Created by lyine on 2021/05/24.
+//  Copyright © 2021 DTS. All rights reserved.
+//
+
+import UIKit
+
+import ReactorKit
+
+import SnapKit
+
+class NoteImageItemCell: BaseCollectionViewCell, View {
+  typealias Reactor = NoteImageItemCellReactor
+  
+  var disposeBag: DisposeBag = DisposeBag()
+  
+  // TODO: ImageView로 변경 예정
+  
+  let containerView = UIView().then {
+    $0.backgroundColor = UIColor(type: .gray1)
+    $0.layer.cornerRadius = 8.0
+    $0.layer.masksToBounds = true
+  }
+  
+  func configure(reactor: Reactor) {
+    super.configure()
+    self.reactor = reactor
+  }
+    
+  func bind(reactor: Reactor) {
+    
+  }
+  
+  override func configureUI() {
+    super.configureUI()
+    
+    [containerView].forEach {
+      self.contentView.addSubview($0)
+    }
+  }
+  
+  override func setupConstraints() {
+    super.setupConstraints()
+    
+    containerView.snp.makeConstraints {
+      $0.edges.equalToSuperview()
+    }
+  }
+}

--- a/Tooda/Sources/Scenes/CreateNote/Cells/NoteLinkCell.swift
+++ b/Tooda/Sources/Scenes/CreateNote/Cells/NoteLinkCell.swift
@@ -15,6 +15,13 @@ class NoteLinkCell: BaseTableViewCell, View {
   typealias Reactor = NoteLinkCellReactor
 
   var disposeBag: DisposeBag = DisposeBag()
+  
+  // MARK: Cell Life Cycle
+  
+  override func prepareForReuse() {
+    super.prepareForReuse()
+    disposeBag = DisposeBag()
+  }
 
   func bind(reactor: Reactor) {
 

--- a/Tooda/Sources/Scenes/CreateNote/Cells/NoteStockCell.swift
+++ b/Tooda/Sources/Scenes/CreateNote/Cells/NoteStockCell.swift
@@ -15,6 +15,13 @@ class NoteStockCell: BaseTableViewCell, View {
   typealias Reactor = NoteStockCellReactor
 
   var disposeBag: DisposeBag = DisposeBag()
+  
+  // MARK: Cell Life Cycle
+  
+  override func prepareForReuse() {
+    super.prepareForReuse()
+    disposeBag = DisposeBag()
+  }
 
   func bind(reactor: Reactor) {
 

--- a/Tooda/Sources/Scenes/CreateNote/Cells/Reactors/EmptyNoteImageItemCellReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/Cells/Reactors/EmptyNoteImageItemCellReactor.swift
@@ -1,0 +1,38 @@
+//
+//  EmptyNoteImageItemCellReactor.swift
+//  Tooda
+//
+//  Created by lyine on 2021/05/24.
+//  Copyright © 2021 DTS. All rights reserved.
+//
+
+import ReactorKit
+
+final class EmptyNoteImageItemCellReactor: Reactor {
+  enum Action {
+    
+  }
+  
+  enum Mutation {
+    
+  }
+  
+  struct State {
+    
+  }
+  
+  let initialState: State
+  
+  init() {
+    initialState = State()
+  }
+  
+  func mutate(action: Action) -> Observable<Mutation> {
+    return .empty()
+  }
+  
+  func reduce(state: State, mutation: Action) -> State {
+    var newState = state
+    return newState
+  }
+}

--- a/Tooda/Sources/Scenes/CreateNote/Cells/Reactors/NoteImageCellReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/Cells/Reactors/NoteImageCellReactor.swift
@@ -127,3 +127,21 @@ let testNotes: [NoteImage] = [
   .init(id: 1, url: "bbbbbbbbb"),
   .init(id: 2, url: "ccccccccc")
 ]
+
+typealias NoteImageSectionType = ([NoteImage]) -> [NoteImageSection]
+
+let noteImageSectionFactory: NoteImageSectionType = { images -> [NoteImageSection] in
+  var sections: [NoteImageSection] = [
+    NoteImageSection.init(identity: .empty, items: []),
+    NoteImageSection.init(identity: .item, items: [])
+  ]
+  
+  let emptyReactor: EmptyNoteImageItemCellReactor = EmptyNoteImageItemCellReactor()
+  let emptySectionItem: NoteImageSectionItem = NoteImageSectionItem.empty(emptyReactor)
+  sections[NoteImageSection.Identity.empty.rawValue].items = [emptySectionItem]
+  
+  let imageSectionItems = images.map { NoteImageItemCellReactor(item: $0) }.map { NoteImageSectionItem.item($0)}
+  sections[NoteImageSection.Identity.item.rawValue].items = imageSectionItems
+  
+  return sections
+}

--- a/Tooda/Sources/Scenes/CreateNote/Cells/Reactors/NoteImageCellReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/Cells/Reactors/NoteImageCellReactor.swift
@@ -8,31 +8,122 @@
 
 import ReactorKit
 
-final class NoteImageCellReactor: Reactor {
-  enum Action {
+enum AppError: Error {
+  case capturingFailed
+}
 
+final class NoteImageCellReactor: Reactor {
+  
+  let scheduler: Scheduler = MainScheduler.asyncInstance
+  
+  struct Dependency {
+    let factory: NoteImageSectionType
+    let authorizationService: AppAuthorizationType
+    let coordinator: AppCoordinatorType
+  }
+  
+  enum Action {
+    case initiailizeSection
+    case didSelectedItem(IndexPath)
+    // TODO: 이미지 추가 로직
+//    case addImage
   }
 
   enum Mutation {
-
+    case fetchSection([NoteImageSection])
+    case didSelctedItem(IndexPath)
+    case requestPermissionMessage(String)
+    case showAlertMessage(String?)
+    case addImage
+    case detailImage
+//    case addImage([NoteImageSectionItem])
   }
 
   struct State {
-
+    var sections: [NoteImageSection]
+    var requestPermissionMessage: String?
+    var showAlertMessage: String?
   }
 
   let initialState: State
+  let dependency: Dependency
+  
+  let disposeBag: DisposeBag = DisposeBag()
 
-  init() {
-    initialState = State()
+  init(dependency: Dependency) {
+    self.dependency = dependency
+    initialState = State(sections: [])
   }
 
   func mutate(action: Action) -> Observable<Mutation> {
-    return .empty()
+    switch action {
+      case .initiailizeSection:
+        return .just(Mutation.fetchSection(self.generateSection(images: testNotes)))
+      case .didSelectedItem(let indexPath):
+        return self.checkAuthorizationAndSelectedItem(indexPath: indexPath)
+    }
   }
-
-  func reduce(state: State, mutation: Action) -> State {
+  
+  func reduce(state: State, mutation: Mutation) -> State {
     var newState = state
+    switch mutation {
+      case .fetchSection(let sections):
+        newState.sections = sections
+      case .requestPermissionMessage(let message):
+        newState.requestPermissionMessage = message
+      case .showAlertMessage(let message):
+        newState.showAlertMessage = message
+      case .addImage:
+        print("이미지 추가")
+      case .detailImage:
+        print("이미지 상세")
+      default:
+        break
+    }
+    
     return newState
   }
+  
+  private func generateSection(images: [NoteImage]) -> [NoteImageSection] {
+    return self.dependency.factory(images)
+  }
+  
+  private func checkAuthorizationAndSelectedItem(indexPath: IndexPath) -> Observable<Mutation> {
+    let service = self.dependency.authorizationService
+    
+    return service.photoLibrary.flatMap { [weak self] status -> Observable<Mutation> in
+      switch status {
+        case .authorized:
+          guard let mutation = self?.didSelectedItem(indexPath) else { return .empty() }
+          return mutation
+        default:
+          return .just(Mutation.requestPermissionMessage("테스트"))
+      }
+    }
+  }
+  
+  private func didSelectedItem(_ indexPath: IndexPath) -> Observable<Mutation> {
+    let selectedSection = indexPath.section
+    
+    guard let matched = NoteImageSection.Identity.allCases.first(where: { $0.rawValue == selectedSection }) else { return .empty() }
+    
+    switch matched {
+      case .empty:
+        
+        let sectionItemsCount = self.currentState.sections[NoteImageSection.Identity.item.rawValue].items.count
+        
+        guard sectionItemsCount < 3 else { return .just(.showAlertMessage("아이템은 최대 3개 까지 등록 가능합니다.")) }
+        
+        return .concat([.just(.showAlertMessage(nil)), .just(.addImage)])
+      case .item:
+        return .concat([.just(.showAlertMessage(nil)), .just(.detailImage)])
+    }
+  }
 }
+
+// TODO: 
+let testNotes: [NoteImage] = [
+  .init(id: 0, url: "aaaaaaaaa"),
+  .init(id: 1, url: "bbbbbbbbb"),
+  .init(id: 2, url: "ccccccccc")
+]

--- a/Tooda/Sources/Scenes/CreateNote/Cells/Reactors/NoteImageCellReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/Cells/Reactors/NoteImageCellReactor.swift
@@ -121,7 +121,7 @@ final class NoteImageCellReactor: Reactor {
   }
 }
 
-// TODO: 
+// TODO: 이미지 셀 영역을 위한 코드, 제거 예정
 let testNotes: [NoteImage] = [
   .init(id: 0, url: "aaaaaaaaa"),
   .init(id: 1, url: "bbbbbbbbb"),

--- a/Tooda/Sources/Scenes/CreateNote/Cells/Reactors/NoteImageItemCellReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/Cells/Reactors/NoteImageItemCellReactor.swift
@@ -1,0 +1,38 @@
+//
+//  NoteImageItemCellReactor.swift
+//  Tooda
+//
+//  Created by lyine on 2021/05/24.
+//  Copyright © 2021 DTS. All rights reserved.
+//
+
+import ReactorKit
+
+final class NoteImageItemCellReactor: Reactor {
+  enum Action {
+    
+  }
+  
+  enum Mutation {
+    
+  }
+  
+  struct State {
+    var item: NoteImage
+  }
+  
+  let initialState: State
+  
+  init(item: NoteImage) {
+    initialState = State(item: item)
+  }
+  
+  func mutate(action: Action) -> Observable<Mutation> {
+    return .empty()
+  }
+  
+  func reduce(state: State, mutation: Action) -> State {
+    var newState = state
+    return newState
+  }
+}

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
@@ -30,6 +30,13 @@ class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
       let cell = tableView.dequeue(EmptyNoteStockCell.self, indexPath: indexPath)
       cell.configure(reactor: reactor)
       return cell
+    case .image(let reactor):
+      let cell = tableView.dequeue(NoteImageCell.self, indexPath: indexPath)
+      cell.configure(reactor: reactor)
+      
+      cell.selectionStyle = .none
+      
+      return cell
     default:
       return UITableViewCell()
     }
@@ -48,6 +55,7 @@ class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
 
     $0.register(NoteContentCell.self)
     $0.register(EmptyNoteStockCell.self)
+    $0.register(NoteImageCell.self)
   }
 
   // MARK: Initialize

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
@@ -48,9 +48,7 @@ class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
   let tableView = UITableView().then {
     $0.separatorStyle = .none
     $0.backgroundColor = .white
-    $0.rowHeight = UITableView.automaticDimension
     $0.estimatedRowHeight = UITableView.automaticDimension
-
     $0.alwaysBounceHorizontal = false
 
     $0.register(NoteContentCell.self)
@@ -112,7 +110,7 @@ class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
       .disposed(by: self.disposeBag)
 
     // State
-    self.reactor?.state
+    reactor.state
       .map { $0.sections }
       .debug()
       .bind(to: self.tableView.rx.items(dataSource: dataSource))

--- a/Tooda/Sources/Scenes/CreateNote/Section/NoteImageSection.swift
+++ b/Tooda/Sources/Scenes/CreateNote/Section/NoteImageSection.swift
@@ -1,0 +1,29 @@
+//
+//  NoteImageSection.swift
+//  Tooda
+//
+//  Created by lyine on 2021/05/24.
+//  Copyright © 2021 DTS. All rights reserved.
+//
+
+import RxDataSources
+
+struct NoteImageSection {
+  enum Identity: Int, CaseIterable {
+    case empty
+    case item
+  }
+  let identity: Identity
+  var items: [NoteImageSectionItem]
+}
+
+extension NoteImageSection: SectionModelType {
+  init(original: NoteImageSection, items: [NoteImageSectionItem]) {
+    self = .init(identity: original.identity, items: items)
+  }
+}
+
+enum NoteImageSectionItem {
+  case empty(EmptyNoteImageItemCellReactor)
+  case item(NoteImageItemCellReactor)
+}


### PR DESCRIPTION
### 수정내역
- 노트 등록 화면에서 이미지 셀을 추가하기 위한 UI작업을 진행했어요.

### Description
- NoteImageSection을 추가했어요, ImageCell의 셀의 역할을 분리하기 위해 섹션을 나눴어요.
- EmptyNoteImageCell을 추가했어요. 탭하면 사진과 관련된 권한을 물어보고, 이미지 피커를 보여주는 역할을 담당할거에요.
- NoteItemImageCell을 추가했어요. 이미지 상단의 x 버튼을 눌렀을 때, 아이템을 삭제하는 기능을 추가할 예정이에요.
- Note Section Factory에 이미지 셀과 관련된 코드를 추가했어요. 이미지 셀 이벤트를 처리하기위해 AuthorizationType과 coordinator를 주입받게 기능을 추가했어요.

### 스크린샷
![ezgif com-gif-maker](https://user-images.githubusercontent.com/19662529/132164862-d2533d38-dd8e-4a4f-866b-b75d5d5f1924.gif)

