### PR TITLE
[Domain] 노트 imageCellReactor를 리팩토링했어요.

### DIFF
--- a/Tooda/Sources/Scenes/CreateNote/Cells/NoteImageCell.swift
+++ b/Tooda/Sources/Scenes/CreateNote/Cells/NoteImageCell.swift
@@ -93,30 +93,9 @@ class NoteImageCell: BaseTableViewCell, View {
       .bind(to: reactor.action)
       .disposed(by: self.disposeBag)
     
-    collectionView.rx.itemSelected
-      .map { Reactor.Action.didSelectedItem($0) }
-      .bind(to: reactor.action)
-      .disposed(by: self.disposeBag)
-    
     reactor.state
       .map { $0.sections }
       .bind(to: collectionView.rx.items(dataSource: dataSource))
-      .disposed(by: self.disposeBag)
-    
-    reactor.state
-      .map { $0.requestPermissionMessage }
-      .filter { $0 != nil }
-      .subscribe(onNext: { [weak self] in
-        self?.showAlertAndOpenAppSetting(message: $0)
-      })
-      .disposed(by: self.disposeBag)
-    
-    reactor.state
-      .map { $0.showAlertMessage }
-      .filter { $0 != nil }
-      .subscribe(onNext: { [weak self] in
-        self?.showAlert(message: $0)
-      })
       .disposed(by: self.disposeBag)
     
     self.collectionView.rx.setDelegate(self).disposed(by: self.disposeBag)
@@ -129,20 +108,5 @@ class NoteImageCell: BaseTableViewCell, View {
 extension NoteImageCell: UICollectionViewDelegateFlowLayout {
   func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
     return .init(top: 0, left: 0, bottom: 0, right: 10)
-  }
-}
-
-extension NoteImageCell {
-  func showAlert(message: String?) {
-    print(message)
-  }
-  
-  func showAlertAndOpenAppSetting(message: String?) {
-    print(message)
-  }
-  
-  private func openAppSettingMenu() {
-    guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
-    UIApplication.shared.open(url, options: [:], completionHandler: nil)
   }
 }

--- a/Tooda/Sources/Scenes/CreateNote/Cells/NoteImageCell.swift
+++ b/Tooda/Sources/Scenes/CreateNote/Cells/NoteImageCell.swift
@@ -7,8 +7,8 @@
 //
 
 import UIKit
-
 import ReactorKit
+import RxCocoa
 import RxDataSources
 import SnapKit
 
@@ -37,7 +37,7 @@ class NoteImageCell: BaseTableViewCell, View {
   
   private let flowLayout: UICollectionViewFlowLayout = UICollectionViewFlowLayout()
   
-  private lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: self.flowLayout).then {
+  lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: self.flowLayout).then {
     
     $0.backgroundColor = .white
     self.flowLayout.scrollDirection = .horizontal
@@ -108,5 +108,13 @@ class NoteImageCell: BaseTableViewCell, View {
 extension NoteImageCell: UICollectionViewDelegateFlowLayout {
   func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
     return .init(top: 0, left: 0, bottom: 0, right: 10)
+  }
+}
+
+// MARK: Reactive Extensions
+
+extension Reactive where Base: NoteImageCell {
+  var didSelectedItemCell: ControlEvent<IndexPath> {
+    return self.base.collectionView.rx.itemSelected
   }
 }

--- a/Tooda/Sources/Scenes/CreateNote/Cells/Reactors/NoteImageCellReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/Cells/Reactors/NoteImageCellReactor.swift
@@ -18,31 +18,18 @@ final class NoteImageCellReactor: Reactor {
   
   struct Dependency {
     let factory: NoteImageSectionType
-    let authorizationService: AppAuthorizationType
-    let coordinator: AppCoordinatorType
   }
   
   enum Action {
     case initiailizeSection
-    case didSelectedItem(IndexPath)
-    // TODO: 이미지 추가 로직
-//    case addImage
   }
 
   enum Mutation {
     case fetchSection([NoteImageSection])
-    case didSelctedItem(IndexPath)
-    case requestPermissionMessage(String)
-    case showAlertMessage(String?)
-    case addImage
-    case detailImage
-//    case addImage([NoteImageSectionItem])
   }
 
   struct State {
     var sections: [NoteImageSection]
-    var requestPermissionMessage: String?
-    var showAlertMessage: String?
   }
 
   let initialState: State
@@ -59,8 +46,6 @@ final class NoteImageCellReactor: Reactor {
     switch action {
       case .initiailizeSection:
         return .just(Mutation.fetchSection(self.generateSection(images: testNotes)))
-      case .didSelectedItem(let indexPath):
-        return self.checkAuthorizationAndSelectedItem(indexPath: indexPath)
     }
   }
   
@@ -69,14 +54,6 @@ final class NoteImageCellReactor: Reactor {
     switch mutation {
       case .fetchSection(let sections):
         newState.sections = sections
-      case .requestPermissionMessage(let message):
-        newState.requestPermissionMessage = message
-      case .showAlertMessage(let message):
-        newState.showAlertMessage = message
-      case .addImage:
-        print("이미지 추가")
-      case .detailImage:
-        print("이미지 상세")
       default:
         break
     }
@@ -86,38 +63,6 @@ final class NoteImageCellReactor: Reactor {
   
   private func generateSection(images: [NoteImage]) -> [NoteImageSection] {
     return self.dependency.factory(images)
-  }
-  
-  private func checkAuthorizationAndSelectedItem(indexPath: IndexPath) -> Observable<Mutation> {
-    let service = self.dependency.authorizationService
-    
-    return service.photoLibrary.flatMap { [weak self] status -> Observable<Mutation> in
-      switch status {
-        case .authorized:
-          guard let mutation = self?.didSelectedItem(indexPath) else { return .empty() }
-          return mutation
-        default:
-          return .just(Mutation.requestPermissionMessage("테스트"))
-      }
-    }
-  }
-  
-  private func didSelectedItem(_ indexPath: IndexPath) -> Observable<Mutation> {
-    let selectedSection = indexPath.section
-    
-    guard let matched = NoteImageSection.Identity.allCases.first(where: { $0.rawValue == selectedSection }) else { return .empty() }
-    
-    switch matched {
-      case .empty:
-        
-        let sectionItemsCount = self.currentState.sections[NoteImageSection.Identity.item.rawValue].items.count
-        
-        guard sectionItemsCount < 3 else { return .just(.showAlertMessage("아이템은 최대 3개 까지 등록 가능합니다.")) }
-        
-        return .concat([.just(.showAlertMessage(nil)), .just(.addImage)])
-      case .item:
-        return .concat([.just(.showAlertMessage(nil)), .just(.detailImage)])
-    }
   }
 }
 

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -85,9 +85,7 @@ let createDiarySectionFactory: CreateNoteSectionType = { authorization, coordina
   let addStockReactor: EmptyNoteStockCellReactor = EmptyNoteStockCellReactor()
   let addStockSectionItem: NoteSectionItem = NoteSectionItem.addStock(addStockReactor)
   
-  let imageReactor: NoteImageCellReactor = NoteImageCellReactor(dependency: .init(factory: noteImageSectionFactory,
-                                                                                  authorizationService: authorization,
-                                                                                  coordinator: coordinator))
+  let imageReactor: NoteImageCellReactor = NoteImageCellReactor(dependency: .init(factory: noteImageSectionFactory))
   let imageSectionItem: NoteSectionItem = NoteSectionItem.image(imageReactor)
 
   sections[NoteSection.Identity.content.rawValue].items = [contentSectionItem]


### PR DESCRIPTION
### 수정내역
- imageCellReactor에 Dependency와 기타 비즈니스 로직을 변경했어요.

### Description
- cellReactor에서 많은 로직들을 가져가기 보다는 ViewControllerReacto에서 가져가는게 좋겠다고 생각이 들었어요. 그래서 imageCellReactor의 비즈니스 로직을 노트작성 Reactor로 변경하는 작업을 진행하려고해요. 
- ImageCellReactor에서 RxAuthorization과 coordinator에 대한 의존성을 제거했어요. 제거한 로직은 다음 PR에 노트작성 Reactor로 반영할 예정입니다!
- ImageCell의 Selected Item을 전달하기위해 Reactive Extension을 추가했어요.
