### PR TITLE
[UI] 노트 등록 이미지 탭 관련 기능을 추가했어요.

### DIFF
--- a/Tooda/Sources/Common/Extensions/UIViewController+Extension.swift
+++ b/Tooda/Sources/Common/Extensions/UIViewController+Extension.swift
@@ -1,0 +1,16 @@
+//
+//  UIViewController+Extension.swift
+//  Tooda
+//
+//  Created by Lyine on 2021/09/18.
+//  Copyright © 2021 DTS. All rights reserved.
+//
+
+import UIKit
+
+extension UIViewController {
+  func openAppSettingMenu() {
+    guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
+    UIApplication.shared.open(url, options: [:], completionHandler: nil)
+  }
+}

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
@@ -177,9 +177,4 @@ extension CreateNoteViewController {
     
     self.present(alertController, animated: true, completion: nil)
   }
-  
-  private func openAppSettingMenu() {
-    guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
-    UIApplication.shared.open(url, options: [:], completionHandler: nil)
-  }
 }

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
@@ -125,8 +125,7 @@ class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
       .disposed(by: self.disposeBag)
     
     reactor.state
-      .map { $0.requestPermissionMessage }
-      .filter { $0 != nil }
+      .compactMap { $0.requestPermissionMessage }
       .observeOn(MainScheduler.asyncInstance)
       .subscribe(onNext: { [weak self] in
         self?.showAlertAndOpenAppSetting(message: $0)
@@ -134,8 +133,7 @@ class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
       .disposed(by: self.disposeBag)
     
     reactor.state
-      .map { $0.showAlertMessage }
-      .filter { $0 != nil }
+      .compactMap { $0.showAlertMessage }
       .observeOn(MainScheduler.asyncInstance)
       .subscribe(onNext: { [weak self] in
         self?.showAlert(message: $0)

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
@@ -35,7 +35,7 @@ class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
       cell.configure(reactor: cellReactor)
       
       cell.rx.didSelectedItemCell
-        .throttle(.milliseconds(5), scheduler: MainScheduler.instance)
+        .throttle(.milliseconds(500), scheduler: MainScheduler.instance)
         .map { Reactor.Action.didSelectedImageItem($0) }
         .subscribe(onNext: { [weak self] in
           self?.reactor?.action.onNext($0)

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
@@ -127,6 +127,7 @@ class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
     reactor.state
       .map { $0.requestPermissionMessage }
       .filter { $0 != nil }
+      .observeOn(MainScheduler.asyncInstance)
       .subscribe(onNext: { [weak self] in
         self?.showAlertAndOpenAppSetting(message: $0)
       })
@@ -135,6 +136,7 @@ class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
     reactor.state
       .map { $0.showAlertMessage }
       .filter { $0 != nil }
+      .observeOn(MainScheduler.asyncInstance)
       .subscribe(onNext: { [weak self] in
         self?.showAlert(message: $0)
       })
@@ -154,11 +156,26 @@ extension CreateNoteViewController {
 
 extension CreateNoteViewController {
   func showAlert(message: String?) {
-    print(message)
+    let alertController = UIAlertController(title: nil, message: message, preferredStyle: .alert)
+    
+    let ok = UIAlertAction.init(title: "확인", style: .default, handler: nil)
+    
+    alertController.addAction(ok)
+    
+    self.present(alertController, animated: true, completion: nil)
   }
   
   func showAlertAndOpenAppSetting(message: String?) {
-    print(message)
+    
+    let alertController = UIAlertController(title: nil, message: message, preferredStyle: .alert)
+    
+    let ok = UIAlertAction.init(title: "확인", style: .default, handler: { [weak self] _ in
+      self?.openAppSettingMenu()
+    })
+    
+    alertController.addAction(ok)
+    
+    self.present(alertController, animated: true, completion: nil)
   }
   
   private func openAppSettingMenu() {

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -97,8 +97,7 @@ final class CreateNoteViewReactor: Reactor {
     switch imageSectionItem {
       case .empty:
         guard imageCellReactor.currentState.sections[NoteImageSection.Identity.item.rawValue].items.count < 3 else {
-          print("이미지는 최대 3개까지 등록 가능합니다.")
-          return .empty()
+          return .just(.showAlertMessage("이미지는 최대 3개까지 등록 가능합니다."))
         }
         
         print("이미지 등록")

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -22,7 +22,6 @@ final class CreateNoteViewReactor: Reactor {
 
   enum Action {
     case initializeForm
-//    case didSelectedItem(IndexPath)
     case dismissView
     case regist
     case didSelectedImageItem(IndexPath)
@@ -78,23 +77,6 @@ final class CreateNoteViewReactor: Reactor {
     let sections = self.dependency.createDiarySectionFactory(self.dependency.authorization, self.dependency.coordinator)
     return sections
   }
-  
-//  private func didSelectedItem(index: IndexPath) {
-//    let selectedSection = index.section
-//
-//    guard let matched = NoteSection.Identity.allCases.first(where: { $0.rawValue == selectedSection }) else { return }
-//
-//    switch matched {
-//      case .content:
-//        print("컨텐츠 섹션")
-//      case .addStock:
-//        print("종목 섹션")
-//      case .link:
-//        print("링크 섹션")
-//      default:
-//        return
-//    }
-//  }
   
   private func didSelectedImageItem(_ indexPath: IndexPath) -> Observable<Mutation> {
     

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -22,16 +22,22 @@ final class CreateNoteViewReactor: Reactor {
 
   enum Action {
     case initializeForm
+//    case didSelectedItem(IndexPath)
     case dismissView
     case regist
+    case didSelectedImageItem(IndexPath)
   }
 
   enum Mutation {
     case initializeForm([NoteSection])
+    case requestPermissionMessage(String)
+    case showAlertMessage(String?)
   }
 
   struct State {
     var sections: [NoteSection]
+    var requestPermissionMessage: String?
+    var showAlertMessage: String?
   }
 
   let initialState: State
@@ -47,6 +53,8 @@ final class CreateNoteViewReactor: Reactor {
     switch action {
     case .initializeForm:
       return .just(Mutation.initializeForm(makeSections()))
+    case .didSelectedImageItem(let index):
+      return checkAuthorizationAndSelectedItem(indexPath: index)
     default:
       return .empty()
     }
@@ -57,6 +65,10 @@ final class CreateNoteViewReactor: Reactor {
     switch mutation {
     case .initializeForm(let sections):
       newState.sections = sections
+    case .requestPermissionMessage(let message):
+      newState.requestPermissionMessage = message
+    case .showAlertMessage(let message):
+      newState.showAlertMessage = message
     }
 
     return newState
@@ -65,6 +77,68 @@ final class CreateNoteViewReactor: Reactor {
   private func makeSections() -> [NoteSection] {
     let sections = self.dependency.createDiarySectionFactory(self.dependency.authorization, self.dependency.coordinator)
     return sections
+  }
+  
+//  private func didSelectedItem(index: IndexPath) {
+//    let selectedSection = index.section
+//
+//    guard let matched = NoteSection.Identity.allCases.first(where: { $0.rawValue == selectedSection }) else { return }
+//
+//    switch matched {
+//      case .content:
+//        print("컨텐츠 섹션")
+//      case .addStock:
+//        print("종목 섹션")
+//      case .link:
+//        print("링크 섹션")
+//      default:
+//        return
+//    }
+//  }
+  
+  private func didSelectedImageItem(_ indexPath: IndexPath) -> Observable<Mutation> {
+    
+    let section = self.currentState.sections[NoteSection.Identity.image.rawValue]
+    
+    guard let imageCellReactor = section.items.compactMap { items -> NoteImageCellReactor? in
+      if case let NoteSectionItem.image(value) = items {
+        return value
+      } else {
+        return nil
+      }
+    }.first else { return .empty() }
+    
+    let imageItemSection = imageCellReactor.currentState.sections[indexPath.section]
+    
+    let imageSectionItem = imageItemSection.items[indexPath.row]
+    
+    switch imageSectionItem {
+      case .empty:
+        guard imageCellReactor.currentState.sections[NoteImageSection.Identity.item.rawValue].items.count < 3 else {
+          print("이미지는 최대 3개까지 등록 가능합니다.")
+          return .empty()
+        }
+        
+        print("이미지 등록")
+      case .item(let reactor):
+        print("이미지 삭제: \(reactor.currentState.item.imageURL)")
+    }
+    
+    return .empty()
+  }
+  
+  private func checkAuthorizationAndSelectedItem(indexPath: IndexPath) -> Observable<Mutation> {
+    let service = self.dependency.authorization
+    
+    return service.photoLibrary.flatMap { [weak self] status -> Observable<Mutation> in
+      switch status {
+        case .authorized:
+          guard let mutation = self?.didSelectedImageItem(indexPath) else { return .empty() }
+          return mutation
+        default:
+          return .just(Mutation.requestPermissionMessage("테스트"))
+      }
+    }
   }
 }
 


### PR DESCRIPTION
### 수정내역
- 노트 이미지 셀에서 하위 컬렉션 아이템을 선택할 때 선택한 아이템에 따라 다른 기능을 추가했어요.

### Description
- 노트 이미지 didSelectedItemCell Reactive Extension 기능을 dataSource에 바인딩했어요.
- CreateNoteViewController에 didSelectedImageItem 기능을 추가했어요.
- didSelectedImageItem의 기능을 러프하게 구현했어요.
  - 이미지를 탭했을 때, 사진 관련 권한을 체크하고, 권한이 체크되어 있지 않으면 퍼미션 관련 Alert을 보내요.
  - 첫번째 이미지셀의 아이템을 탭했을 때, 아이템의 갯수가 최대 3개 미만까지는 이미지 등록 관련 기능을 수행할 예정이에요.
