### PR TITLE
[UI] 노트 등록 화면에 ImagePickerController를 연결했어요.

### DIFF
--- a/Tooda/Sources/Common/UIColor+Extension.swift
+++ b/Tooda/Sources/Common/UIColor+Extension.swift
@@ -92,10 +92,6 @@ extension UIColor {
   class var gray4: UIColor {
     return .init(hex: "#EFF0F3")
   }
-
-  class var gray5: UIColor {
-    return .init(hex: "#F7F8FA")
-  }
   
   class var gray5: UIColor {
     return .init(hex: "#F7F8FA")

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
@@ -145,7 +145,7 @@ class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
       .compactMap { $0 }
       .asDriver(onErrorJustReturn: ())
       .drive(onNext: { [weak self] _ in
-        self?.actionSheetAlert()
+        self?.showPhotoPicker()
       }).disposed(by: self.disposeBag)
   }
 }
@@ -182,6 +182,33 @@ extension CreateNoteViewController {
     alertController.addAction(ok)
     
     self.present(alertController, animated: true, completion: nil)
+  }
+  
+  private func showPhotoPicker() {
+    let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+    
+    let cancel = UIAlertAction(title: "취소", style: .cancel, handler: nil)
+    let camera = UIAlertAction(title: "카메라", style: .default) { [weak self] _ in
+      self?.showPickView(by: .camera)
+    }
+    let album = UIAlertAction(title: "앨범", style: .default) { [weak self] _ in
+      self?.showPickView(by: .photoLibrary)
+    }
+    
+    alert.addAction(cancel)
+    alert.addAction(camera)
+    alert.addAction(album)
+    
+    present(alert, animated: true, completion: nil)
+  }
+  
+  private func showPickView(by: UIImagePickerController.SourceType) {
+    let vc = UIImagePickerController()
+    vc.sourceType = by
+    vc.delegate = self
+    vc.allowsEditing = true
+    
+    present(vc, animated: true, completion: nil)
   }
 }
 

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
@@ -219,8 +219,8 @@ extension CreateNoteViewController: UIImagePickerControllerDelegate, UINavigatio
   
   func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
     
-    if let image = info[.editedImage] as? UIImage {
-      dump(image)
+    if let image = info[.editedImage] as? UIImage, let imageData = image.jpegData(compressionQuality: 1.0) {
+      self.reactor?.action.onNext(.uploadImage(imageData))
     }
     
     picker.dismiss(animated: true, completion: nil)

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
@@ -139,6 +139,14 @@ class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
         self?.showAlert(message: $0)
       })
       .disposed(by: self.disposeBag)
+    
+    reactor.state
+      .map { $0.showPhotoPicker }
+      .compactMap { $0 }
+      .asDriver(onErrorJustReturn: ())
+      .drive(onNext: { [weak self] _ in
+        self?.actionSheetAlert()
+      }).disposed(by: self.disposeBag)
   }
 }
 
@@ -174,5 +182,20 @@ extension CreateNoteViewController {
     alertController.addAction(ok)
     
     self.present(alertController, animated: true, completion: nil)
+  }
+}
+
+extension CreateNoteViewController: UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+  func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+    picker.dismiss(animated: true, completion: nil)
+  }
+  
+  func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
+    
+    if let image = info[.editedImage] as? UIImage {
+      dump(image)
+    }
+    
+    picker.dismiss(animated: true, completion: nil)
   }
 }

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -35,6 +35,7 @@ final class CreateNoteViewReactor: Reactor {
     case showPhotoPicker
   }
 
+  // TODO: sections외 다른 변수들을 하나의 enum으로 관리할 수 있는 방법으로 리팩토링 예정
   struct State {
     var sections: [NoteSection]
     var requestPermissionMessage: String?

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -22,7 +22,6 @@ final class CreateNoteViewReactor: Reactor {
 
   enum Action {
     case initializeForm
-//    case didSelectedItem(IndexPath)
     case dismissView
     case regist
     case didSelectedImageItem(IndexPath)

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -31,12 +31,14 @@ final class CreateNoteViewReactor: Reactor {
     case initializeForm([NoteSection])
     case requestPermissionMessage(String)
     case showAlertMessage(String?)
+    case showPhotoPicker
   }
 
   struct State {
     var sections: [NoteSection]
     var requestPermissionMessage: String?
     var showAlertMessage: String?
+    var showPhotoPicker: Void?
   }
 
   let initialState: State
@@ -68,6 +70,8 @@ final class CreateNoteViewReactor: Reactor {
       newState.requestPermissionMessage = message
     case .showAlertMessage(let message):
       newState.showAlertMessage = message
+    case .showPhotoPicker:
+      newState.showPhotoPicker = ()
     }
 
     return newState
@@ -100,7 +104,7 @@ final class CreateNoteViewReactor: Reactor {
           return .just(.showAlertMessage("이미지는 최대 3개까지 등록 가능합니다."))
         }
         
-        print("이미지 등록")
+        return .just(.showPhotoPicker)
       case .item(let reactor):
         print("이미지 삭제: \(reactor.currentState.item.imageURL)")
     }

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -22,6 +22,7 @@ final class CreateNoteViewReactor: Reactor {
 
   enum Action {
     case initializeForm
+//    case didSelectedItem(IndexPath)
     case dismissView
     case regist
     case didSelectedImageItem(IndexPath)

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -25,6 +25,7 @@ final class CreateNoteViewReactor: Reactor {
     case dismissView
     case regist
     case didSelectedImageItem(IndexPath)
+    case uploadImage(Data)
   }
 
   enum Mutation {
@@ -56,6 +57,8 @@ final class CreateNoteViewReactor: Reactor {
       return .just(Mutation.initializeForm(makeSections()))
     case .didSelectedImageItem(let index):
       return checkAuthorizationAndSelectedItem(indexPath: index)
+    case .uploadImage(let data):
+      return .empty()
     default:
       return .empty()
     }
@@ -124,6 +127,16 @@ final class CreateNoteViewReactor: Reactor {
           return .just(Mutation.requestPermissionMessage("테스트"))
       }
     }
+  }
+}
+
+// MARK: Upload Images
+
+extension CreateNoteViewReactor {
+  private func uploadImage(_ data: Data) -> Observable<String> {
+    return self.dependency.service.request(NoteAPI.addImage(data: data))
+      .map(String.self)
+      .asObservable()
   }
 }
 

--- a/Tooda/Sources/Scenes/Home/Cells/NotebookCell.swift
+++ b/Tooda/Sources/Scenes/Home/Cells/NotebookCell.swift
@@ -87,6 +87,13 @@ class NotebookCell: UICollectionViewCell {
     fatalError("init(coder:) has not been implemented")
   }
 
+  override func prepareForReuse() {
+    super.prepareForReuse()
+    self.stickers.forEach {
+      $0.image = nil
+    }
+  }
+
 
   // MARK: Configuring
 


### PR DESCRIPTION
### 수정내역
- 노트 등록화면에 ImagePicker 관련 코드 추가,  Delegate 코드 구현, Reactor Action, Mutation 정의

### Description
- 노트 등록 ViewController에서 showPhotoPicker 메소드를 추가했어요.
- 노트 등록 ViewController에서 imagePickerController Delegate 코드를 구현했어요.
- ImagePickerController Delegate에서 전달받은 ImageData는 Reactor Action으로 보내요.
- 노트 등록 Reactor에서 addImage 관련 request 메소드를 추가했어요.
- 노트 등록 Reactor에서 불필요한 SelectedItem Action case를 제거했어요.

### 스크린샷
![ezgif com-gif-maker](https://user-images.githubusercontent.com/19662529/133923622-a337d326-c3f1-4e24-9f5a-a52d6ce4f9f9.gif)


