### PR TITLE
[UI] 이미지 피커의 imageData를 이미지 Cell에 넣어주고 리팩토링 작업을 진행했어요.

### DIFF
--- a/Tooda/Sources/Scenes/CreateNote/Cells/NoteImageCell.swift
+++ b/Tooda/Sources/Scenes/CreateNote/Cells/NoteImageCell.swift
@@ -89,7 +89,7 @@ class NoteImageCell: BaseTableViewCell, View {
   func bind(reactor: Reactor) {
     
     Observable.just(())
-      .map { _ in Reactor.Action.initiailizeSection }
+      .map { _ in Reactor.Action.fetchSections }
       .bind(to: reactor.action)
       .disposed(by: self.disposeBag)
     

--- a/Tooda/Sources/Scenes/CreateNote/Cells/Reactors/NoteImageCellReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/Cells/Reactors/NoteImageCellReactor.swift
@@ -104,13 +104,6 @@ final class NoteImageCellReactor: Reactor {
   }
 }
 
-// TODO: 이미지 셀 영역을 위한 코드, 제거 예정
-let testNotes: [NoteImage] = [
-  .init(id: 0, url: "aaaaaaaaa"),
-  .init(id: 1, url: "bbbbbbbbb"),
-  .init(id: 2, url: "ccccccccc")
-]
-
 typealias NoteImageSectionType = ([NoteImage]) -> [NoteImageSection]
 
 let noteImageSectionFactory: NoteImageSectionType = { images -> [NoteImageSection] in

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
@@ -126,7 +126,6 @@ class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
     // State
     reactor.state
       .map { $0.sections }
-      .debug()
       .bind(to: self.tableView.rx.items(dataSource: dataSource))
       .disposed(by: self.disposeBag)
     

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
@@ -130,27 +130,10 @@ class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
       .disposed(by: self.disposeBag)
     
     reactor.state
-      .compactMap { $0.requestPermissionMessage }
-      .observeOn(MainScheduler.asyncInstance)
-      .subscribe(onNext: { [weak self] in
-        self?.showAlertAndOpenAppSetting(message: $0)
-      })
-      .disposed(by: self.disposeBag)
-    
-    reactor.state
-      .compactMap { $0.showAlertMessage }
-      .observeOn(MainScheduler.asyncInstance)
-      .subscribe(onNext: { [weak self] in
-        self?.showAlert(message: $0)
-      })
-      .disposed(by: self.disposeBag)
-    
-    reactor.state
-      .map { $0.showPhotoPicker }
-      .compactMap { $0 }
-      .asDriver(onErrorJustReturn: ())
-      .drive(onNext: { [weak self] _ in
-        self?.showPhotoPicker()
+      .compactMap { $0.presentType }
+      .asDriver(onErrorJustReturn: .showPhotoPicker)
+      .drive(onNext: { [weak self] in
+        self?.present(by: $0)
       }).disposed(by: self.disposeBag)
   }
 }
@@ -166,6 +149,17 @@ extension CreateNoteViewController {
 // MARK: ETC
 
 extension CreateNoteViewController {
+  func present(by: Reactor.ViewPresentType) {
+    switch by {
+      case .showAlert(let message):
+        self.showAlert(message: message)
+      case .showPermission(let message):
+        self.showAlertAndOpenAppSetting(message: message)
+      case .showPhotoPicker:
+        self.showPhotoPicker()
+    }
+  }
+  
   func showAlert(message: String?) {
     let alertController = UIAlertController(title: nil, message: message, preferredStyle: .alert)
     

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
@@ -22,6 +22,7 @@ class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
   // MARK: Custom Action
   
   let imageItemCellDidTapRelay: PublishRelay<IndexPath> = PublishRelay()
+  let imagePickerDataSelectedRelay: PublishRelay<Data> = PublishRelay()
   
   // MARK: Properties
   lazy var dataSource: Section = Section(configureCell: { _, tableView, indexPath, item -> UITableViewCell in
@@ -123,6 +124,11 @@ class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
       .bind(to: reactor.action)
       .disposed(by: self.disposeBag)
     
+    imagePickerDataSelectedRelay
+      .map { Reactor.Action.uploadImage($0) }
+      .bind(to: reactor.action)
+      .disposed(by: self.disposeBag)
+    
     // State
     reactor.state
       .map { $0.sections }
@@ -219,7 +225,7 @@ extension CreateNoteViewController: UIImagePickerControllerDelegate, UINavigatio
   func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
     
     if let image = info[.editedImage] as? UIImage, let imageData = image.jpegData(compressionQuality: 1.0) {
-      self.reactor?.action.onNext(.uploadImage(imageData))
+      self.imagePickerDataSelectedRelay.accept(imageData)
     }
     
     picker.dismiss(animated: true, completion: nil)

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -22,7 +22,6 @@ final class CreateNoteViewReactor: Reactor {
 
   enum Action {
     case initializeForm
-//    case didSelectedItem(IndexPath)
     case dismissView
     case regist
     case didSelectedImageItem(IndexPath)

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -22,6 +22,7 @@ final class CreateNoteViewReactor: Reactor {
 
   enum Action {
     case initializeForm
+//    case didSelectedItem(IndexPath)
     case dismissView
     case regist
     case didSelectedImageItem(IndexPath)

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -41,7 +41,6 @@ final class CreateNoteViewReactor: Reactor {
     case fetchImageSection(NoteSectionItem)
   }
 
-  // TODO: sections외 다른 변수들을 하나의 enum으로 관리할 수 있는 방법으로 리팩토링 예정
   struct State: Then {
     var sections: [NoteSection] = []
     var presentType: ViewPresentType?

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -73,7 +73,6 @@ final class CreateNoteViewReactor: Reactor {
 
   func reduce(state: State, mutation: Mutation) -> State {
     
-    // do, then 을해서 초기값을 막아줄 수 있음
     var newState = State().with {
       $0.sections = state.sections
       $0.presentType = nil

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import ReactorKit
+import Then
 
 final class CreateNoteViewReactor: Reactor {
   
@@ -37,8 +38,8 @@ final class CreateNoteViewReactor: Reactor {
   }
 
   // TODO: sections외 다른 변수들을 하나의 enum으로 관리할 수 있는 방법으로 리팩토링 예정
-  struct State {
-    var sections: [NoteSection]
+  struct State: Then {
+    var sections: [NoteSection] = []
     var requestPermissionMessage: String?
     var showAlertMessage: String?
     var showPhotoPicker: Void?
@@ -50,7 +51,7 @@ final class CreateNoteViewReactor: Reactor {
 
   init(dependency: Dependency) {
     self.dependency = dependency
-    self.initialState = State(sections: [])
+    self.initialState = State()
   }
 
   func mutate(action: Action) -> Observable<Mutation> {
@@ -70,7 +71,15 @@ final class CreateNoteViewReactor: Reactor {
   }
 
   func reduce(state: State, mutation: Mutation) -> State {
-    var newState = state
+    
+    // do, then 을해서 초기값을 막아줄 수 있음
+    var newState = State().with {
+      $0.sections = state.sections
+      $0.requestPermissionMessage = nil
+      $0.showAlertMessage = nil
+      $0.showPhotoPicker = nil
+    }
+    
     switch mutation {
     case .initializeForm(let sections):
       newState.sections = sections
@@ -141,9 +150,7 @@ final class CreateNoteViewReactor: Reactor {
 
 extension CreateNoteViewReactor {
   private func uploadImage(_ data: Data) -> Observable<String> {
-    return self.dependency.service.request(NoteAPI.addImage(data: data))
-      .map(String.self)
-      .asObservable()
+    return Observable.just("aaaaa")
   }
 }
 

--- a/Tooda/Sources/Scenes/CreateNote/Section/NoteSection.swift
+++ b/Tooda/Sources/Scenes/CreateNote/Section/NoteSection.swift
@@ -13,8 +13,8 @@ struct NoteSection {
     case content
     case stock
     case addStock
-    case link
     case image
+    case link
   }
   let identity: Identity
   var items: [NoteSectionItem]


### PR DESCRIPTION
### 수정내역
- imageData를 imageCellReactor에 넣어주는 기능을 추가했어요.
- #45 코멘트남긴 기능에 대한 리팩토링

### Description
- image 등록 이후 image cell state 기본값이 빈 값으로 인해 sectionItem들이 초기화 되는 문제를 수정했어요.
- imagePicker에서 선택된 imageData를 imagePickerDataSelectedRelay에 전달하여 bind 스코프 내에서 데이터를 처리할 수 있도록 변경했어요.
- 노트등록 Reactor State에서 viewController로 단순히 전달용으로 사용하던 state 멤버변수를 하나로 관리하기 위해 내부 Enum으로 변경해서 처리하도록 변경했어요.
