### PR TITLE
[Network] AccessTokenPlugin에 localPersistance 의존성을 추가했어요.

### DIFF
--- a/Tooda/Sources/Core/AppInject.swift
+++ b/Tooda/Sources/Core/AppInject.swift
@@ -26,10 +26,6 @@ final class AppInject: AppInjectRegister, AppInjectResolve {
   }
   
   func registerCore() {
-    container.register(NetworkingProtocol.self) { _ in
-      Networking(logger: [AccessTokenPlugin()])
-    }
-    
     container.register(AppCoordinatorType.self) { _ in
       AppCoordinator(
         dependency: .init(
@@ -75,6 +71,10 @@ final class AppInject: AppInjectRegister, AppInjectResolve {
     
     container.register(AppAuthorizationType.self) { _ in
       RxAuthorization()
+    }
+    
+    container.register(NetworkingProtocol.self) { _ in
+      Networking(logger: [AccessTokenPlugin(localPersistance: self.resolve(LocalPersistanceManagerType.self))])
     }
   }
   

--- a/Tooda/Sources/Networking/AccessTokenPlugin.swift
+++ b/Tooda/Sources/Networking/AccessTokenPlugin.swift
@@ -10,17 +10,22 @@ import Foundation
 import Moya
 
 final class AccessTokenPlugin: PluginType {
+  
+  let localPersistance: LocalPersistanceManagerType
+  
+  init(localPersistance: LocalPersistanceManagerType) {
+    self.localPersistance = localPersistance
+  }
 
   func prepare(_ request: URLRequest, target: TargetType) -> URLRequest {
 
-//		let token = AppManager.shared.accessToken
-//		let keychain = Keychain()
-//
-//		var request = request
-//
-//		if token.isNotEmpty {
-//			request.addValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-//		}
+    let token: AppToken? = localPersistance.objectValue(forKey: .appToken)
+
+		var request = request
+    
+    if let token = token, !token.accessToken.isEmpty {
+      request.addValue("Bearer \(token.accessToken)", forHTTPHeaderField: "Authorization")
+		}
 
     return request
   }


### PR DESCRIPTION
### 수정내역
- keyChain에 저장된 AppToken을 AccessTokenPlugin에 사용할 수 있는 기능을 추가했어요.

### Description
- AccessTokenPlugin에 localPersistance 멤버변수를 추가했어요.
- AccessToken에서 prepare할 때, Token을 값을 꺼내와서 request에 addValue하는 로직을 추가했어요.
- AppInject에 AccessToken에 대한 localPersistance를 DI Container에 등록했어요.

### 스크린샷 (선택사항)
-
