### PR TITLE
[UI/Util] UITableView dequeue cell extension 함수 추가했어요

### DIFF
--- a/Tooda/Sources/Common/Extensions/UITableViewCell+Extension.swift
+++ b/Tooda/Sources/Common/Extensions/UITableViewCell+Extension.swift
@@ -28,6 +28,10 @@ extension UITableView {
     return self.dequeueReusableCell(withIdentifier: T.reuseIdentifier, for: indexPath) as! T
   }
   
+  func dequeue<T>(_ cellType: T.Type) -> T where T: CellType {
+    return self.dequeueReusableCell(withIdentifier: T.reuseIdentifier) as! T
+  }
+  
   func register<T>(_ cellType: T.Type) where T: CellType {
     self.register(T.self, forCellReuseIdentifier: T.reuseIdentifier)
   }


### PR DESCRIPTION
### 수정내역
- indexPath 없이 reuseIdentifier 만으로 dequeue cell 하는 함수가 없어서 추가

### Description

```swift
func dequeue<T>(_ cellType: T.Type) -> T where T: CellType {
    return self.dequeueReusableCell(withIdentifier: T.reuseIdentifier) as! T
}

```