### PR TITLE
[UI] NoteImageItem을 제거하는 기능을 추가했어요.

### DIFF
--- a/Tooda/Sources/Scenes/CreateNote/Cells/Reactors/NoteImageCellReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/Cells/Reactors/NoteImageCellReactor.swift
@@ -23,6 +23,7 @@ final class NoteImageCellReactor: Reactor {
   enum Action {
     case fetchSections
     case addImage(String)
+    case removeImage(IndexPath)
   }
 
   enum Mutation {
@@ -49,6 +50,8 @@ final class NoteImageCellReactor: Reactor {
         return self.fetchAlreadyExistSections()
       case .addImage(let url):
         return self.addImageSectionItem(imageURL: url)
+      case .removeImage(let index):
+        return self.removeImageSectionItems(index)
     }
   }
   
@@ -97,6 +100,19 @@ final class NoteImageCellReactor: Reactor {
     var sectionItems = sections[NoteImageSection.Identity.item.rawValue].items
     
     sectionItems.append(sectionItem)
+    
+    sections[NoteImageSection.Identity.item.rawValue].items = sectionItems
+    
+    return .just(.fetchSection(sections))
+  }
+  
+  private func removeImageSectionItems(_ index: IndexPath) -> Observable<Mutation> {
+    
+    var sections = self.currentState.sections
+    
+    var sectionItems = sections[NoteImageSection.Identity.item.rawValue].items
+    
+    sectionItems.remove(at: index.row)
     
     sections[NoteImageSection.Identity.item.rawValue].items = sectionItems
     

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -118,8 +118,8 @@ final class CreateNoteViewReactor: Reactor {
         }
         
         return .just(.present(.showPhotoPicker))
-      case .item(let reactor):
-        print("이미지 삭제: \(reactor.currentState.item.imageURL)")
+      case .item:
+        imageCellReactor.action.onNext(.removeImage(indexPath))
     }
     
     return .empty()


### PR DESCRIPTION
### 수정내역
- NoteImageItem의 삭제버튼 기능 구현

### Description
- NoteImageItem의 closebutton을 탭하면, 노트등록 Reactor에서 해당 리액터에 remove action을 보내주는 코드를 추가했어요.
- NoteImageItemReactor에서 removeImage에 대한 action, mutation을 정의하고, 메소드를 추가했어요.
