### PR TITLE
[UI] 커스텀 MarginLabel 추가

### DIFF
--- a/Tooda/Sources/Common/MarginLabel.swift
+++ b/Tooda/Sources/Common/MarginLabel.swift
@@ -1,0 +1,79 @@
+//
+//  MarginLabel.swift
+//  Tooda
+//
+//  Created by 황재욱 on 2021/10/31.
+//  Copyright © 2021 DTS. All rights reserved.
+//
+
+import UIKit
+
+final class MarginLabel: UILabel {
+  
+  // MARK: - Types
+  
+  enum VerticalAlignment {
+    case top
+    case bottom
+    case middle
+    case none
+  }
+  
+  // MARK: - Properties
+  
+  private let edgeInsets: UIEdgeInsets
+  
+  var verticalAlignment: VerticalAlignment = .none {
+    didSet {
+      self.setNeedsDisplay()
+    }
+  }
+  
+  // MARK: - Constructor
+  
+  init(edgeInsets: UIEdgeInsets) {
+    self.edgeInsets = edgeInsets
+    super.init(frame: .zero)
+  }
+  
+  required init?(coder aDecoder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  // MARK: - Overridden: ParentClass
+  
+  override var intrinsicContentSize: CGSize {
+    let size = super.intrinsicContentSize
+    return CGSize(width: size.width + edgeInsets.left + edgeInsets.right,
+                  height: size.height + edgeInsets.top + edgeInsets.bottom)
+  }
+  
+  override func textRect(forBounds bounds: CGRect, limitedToNumberOfLines numberOfLines: Int) -> CGRect {
+    var textRect:CGRect = super.textRect(forBounds: bounds, limitedToNumberOfLines: numberOfLines)
+    
+    switch self.verticalAlignment {
+    case .top:
+      textRect.origin.y = bounds.origin.y
+    case .bottom:
+      textRect.origin.y = bounds.origin.y + bounds.size.height - textRect.size.height
+    case .middle:
+      textRect.origin.y = bounds.origin.y + (bounds.size.height - textRect.size.height) / 2.0
+    case .none:
+      break
+    }
+    
+    return textRect
+  }
+  
+  override func drawText(in rect: CGRect) {
+    if verticalAlignment == .none {
+      super.drawText(in: rect.inset(by: edgeInsets))
+    } else {
+      let actualRect = self.textRect(
+        forBounds: rect,
+        limitedToNumberOfLines: self.numberOfLines
+      )
+      super.drawText(in: actualRect)
+    }
+  }
+}

--- a/Tooda/Sources/Common/MarginLabel.swift
+++ b/Tooda/Sources/Common/MarginLabel.swift
@@ -44,12 +44,20 @@ final class MarginLabel: UILabel {
   
   override var intrinsicContentSize: CGSize {
     let size = super.intrinsicContentSize
-    return CGSize(width: size.width + edgeInsets.left + edgeInsets.right,
-                  height: size.height + edgeInsets.top + edgeInsets.bottom)
+    return CGSize(
+      width: size.width + edgeInsets.left + edgeInsets.right,
+      height: size.height + edgeInsets.top + edgeInsets.bottom
+    )
   }
   
-  override func textRect(forBounds bounds: CGRect, limitedToNumberOfLines numberOfLines: Int) -> CGRect {
-    var textRect:CGRect = super.textRect(forBounds: bounds, limitedToNumberOfLines: numberOfLines)
+  override func textRect(
+    forBounds bounds: CGRect,
+    limitedToNumberOfLines numberOfLines: Int
+  ) -> CGRect {
+    var textRect:CGRect = super.textRect(
+      forBounds: bounds,
+      limitedToNumberOfLines: numberOfLines
+    )
     
     switch self.verticalAlignment {
     case .top:


### PR DESCRIPTION
### 수정내역 (필수)
- margin 정해서 사용할 수 있는 MarginLabel 추가

### 스크린샷 (선택사항)
- 여기에서 사용할 예정
<img width="96" alt="스크린샷 2021-10-31 오후 3 54 27" src="https://user-images.githubusercontent.com/31857308/139572144-b1ec5f23-d728-44be-b39e-98fced612f2b.png">

