### PR TITLE
[Bug] 네비게이션바 백버튼을 하면 current 히스토리가 안 남는 문제를 수정합니다.

### DIFF
--- a/Tooda/Sources/Base/BaseViewController.swift
+++ b/Tooda/Sources/Base/BaseViewController.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 import ReactorKit
+import RxSwift
 
 class BaseViewController<T: Reactor>: UIViewController, View {
   typealias Reactor = T
@@ -33,4 +34,20 @@ class BaseViewController<T: Reactor>: UIViewController, View {
   
   func configureUI() {}
   func configureConstraints() {}
+
+  @discardableResult
+  func configureBackBarButtonItemIfNeeded() -> Observable<Void> {
+    Observable<Void>.create({ observer in
+      if self.navigationController?.viewControllers.count ?? 0 >= 2 {
+        self.navigationItem.leftBarButtonItem = UIBarButtonItem(
+          image: .init(type: .backBarButton),
+          style: .plain,
+          action: {
+            observer.onNext(())
+          }
+        )
+      }
+      return Disposables.create()
+    })
+  }
 }

--- a/Tooda/Sources/Common/Extensions/UIBarButtonItem+Extension.swift
+++ b/Tooda/Sources/Common/Extensions/UIBarButtonItem+Extension.swift
@@ -1,0 +1,40 @@
+//
+//  UIBarButtonItem+Extension.swift
+//  Tooda
+//
+//  Created by Jinsu Park on 2021/11/06.
+//  Copyright © 2021 DTS. All rights reserved.
+//
+
+import UIKit
+
+extension UIBarButtonItem {
+  
+  private struct AssociatedKeys {
+    static var targetClosure = "targetClosure"
+  }
+  
+  private var _action: (() -> Void)? {
+    get {
+      return objc_getAssociatedObject(self, &AssociatedKeys.targetClosure) as? () -> Void
+    }
+    set {
+      objc_setAssociatedObject(
+        self,
+        &AssociatedKeys.targetClosure,
+        newValue,
+        objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC
+      )
+    }
+  }
+  
+  convenience init(image: UIImage?, style: UIBarButtonItem.Style, action: @escaping () -> Void) {
+    self.init(image: image, style: style, target: nil, action: #selector(pressed))
+    self.target = self
+    self._action = action
+  }
+  
+  @objc private func pressed(sender: UIBarButtonItem) {
+    _action?()
+  }
+}

--- a/Tooda/Sources/Scenes/Home/HomeViewController.swift
+++ b/Tooda/Sources/Scenes/Home/HomeViewController.swift
@@ -126,6 +126,8 @@ final class HomeViewController: BaseViewController<HomeReactor> {
     self.rxPickDate
       .asObservable()
       .map { HomeReactor.Action.pickDate($0) }
+      .bind(to: reactor.action)
+      .disposed(by: self.disposeBag)
 
     self.searchBarButton.rx.tap
       .map { HomeReactor.Action.pushSearch }

--- a/Tooda/Sources/Scenes/Search/SearchReactor.swift
+++ b/Tooda/Sources/Scenes/Search/SearchReactor.swift
@@ -24,7 +24,7 @@ final class SearchReactor: Reactor {
   // MARK: Reactor
 
   enum Action {
-
+    case back
   }
 
   enum Mutation {
@@ -53,7 +53,15 @@ final class SearchReactor: Reactor {
 extension SearchReactor {
 
   func mutate(action: Action) -> Observable<Mutation> {
-    return Observable<Mutation>.empty()
+    switch action {
+    case .back:
+      self.dependency.coordinator.close(
+        style: .pop,
+        animated: true,
+        completion: nil
+      )
+      return Observable<Mutation>.empty()
+    }
   }
 
 }

--- a/Tooda/Sources/Scenes/Search/SearchViewController.swift
+++ b/Tooda/Sources/Scenes/Search/SearchViewController.swift
@@ -41,6 +41,13 @@ final class SearchViewController: BaseViewController<SearchReactor> {
 
   override func bind(reactor: SearchReactor) {
 
+    // Action
+    self.rx.viewDidLoad
+      .asObservable()
+      .flatMap { self.configureBackBarButtonItemIfNeeded() }
+      .map { SearchReactor.Action.back }
+      .bind(to: reactor.action)
+      .disposed(by: self.disposeBag)
   }
 
   override func configureUI() {

--- a/Tooda/Sources/Scenes/Search/SearchViewController.swift
+++ b/Tooda/Sources/Scenes/Search/SearchViewController.swift
@@ -44,7 +44,11 @@ final class SearchViewController: BaseViewController<SearchReactor> {
     // Action
     self.rx.viewDidLoad
       .asObservable()
-      .flatMap { self.configureBackBarButtonItemIfNeeded() }
+      .flatMap { [weak self] _ -> Observable<Void> in
+        guard let self = self else {
+          return Observable<Void>.empty()
+        }
+        return self.configureBackBarButtonItemIfNeeded() }
       .map { SearchReactor.Action.back }
       .bind(to: reactor.action)
       .disposed(by: self.disposeBag)


### PR DESCRIPTION
### 수정내역 (필수)
- 네비게이션바 백버튼을 커스터마이징 해서 close도 coordinator를 거치게 해요.
- 
![image](https://user-images.githubusercontent.com/24262765/140601270-4feafb21-0d5b-4278-8749-cd1263494c55.png)
- 다음과 같이 백버튼이 필요한 화면에는 viewDidload와 flatMap해서 configure하시면 될 것 같아요.
- Coordinator가 매우 문제가 많네요. 나중에 리팩토링 할 일 생기면 코디네이터 덜어내야될 것 같아요.
