### PR TITLE
[UI] 종목 기록하기 화면의 입력 기능을 구현했어요.

### DIFF
--- a/Tooda/Sources/Core/AppFactory.swift
+++ b/Tooda/Sources/Core/AppFactory.swift
@@ -66,7 +66,8 @@ final class AppFactory: AppFactoryType {
       let reator = AddStockReactor(
         dependency: .init(
           completionRelay: completionRelay,
-          coordinator: self.dependency.appInject.resolve(AppCoordinatorType.self)
+          coordinator: self.dependency.appInject.resolve(AppCoordinatorType.self),
+          service: self.dependency.appInject.resolve(NetworkingProtocol.self)
         )
       )
       let viewController = AddStockViewController(reactor: reator)

--- a/Tooda/Sources/Core/AppFactory.swift
+++ b/Tooda/Sources/Core/AppFactory.swift
@@ -63,7 +63,12 @@ final class AppFactory: AppFactoryType {
       return SettingsViewController(reactor: reactor)
       
     case .addStock(let completionRelay):
-      let reator = AddStockReactor(dependency: .init(completionRelay: completionRelay))
+      let reator = AddStockReactor(
+        dependency: .init(
+          completionRelay: completionRelay,
+          coordinator: self.dependency.appInject.resolve(AppCoordinatorType.self)
+        )
+      )
       let viewController = AddStockViewController(reactor: reator)
       let navigationController = UINavigationController(rootViewController: viewController)
       navigationController.modalPresentationStyle = .overFullScreen

--- a/Tooda/Sources/Networking/API/SotckAPI.swift
+++ b/Tooda/Sources/Networking/API/SotckAPI.swift
@@ -16,7 +16,7 @@ extension StockAPI: BaseAPI {
   var path: String {
     switch self {
       case .search:
-        return "/stock/search"
+        return "stock/search"
     }
   }
   

--- a/Tooda/Sources/Scenes/AddStock/AddStockReactor.swift
+++ b/Tooda/Sources/Scenes/AddStock/AddStockReactor.swift
@@ -28,6 +28,7 @@ final class AddStockReactor: Reactor {
   struct Dependency {
     let completionRelay: PublishRelay<String>
     let coordinator: AppCoordinatorType
+    let service: NetworkingProtocol
   }
   
   struct State {
@@ -54,10 +55,7 @@ extension AddStockReactor {
   func mutate(action: Action) -> Observable<Mutation> {
     switch action {
       case .searchTextDidChanged(let keyword):
-        print(keyword)
-        
-        // TODO: Search API dependency 추가
-        return .empty()
+        return self.searchTextDidChanged(keyword)
       case .dismiss:
         return self.dissmissView()
     }
@@ -86,5 +84,20 @@ extension AddStockReactor {
     )
     
     return .empty()
+  }
+}
+
+// MARK: Seacrh Stock
+
+extension AddStockReactor {
+  private func searchTextDidChanged(_ keyword: String) -> Observable<Mutation> {
+    self.dependency.service.request(StockAPI.search(keyword: keyword))
+      .asObservable()
+      .mapString()
+      .debug()
+      // TestCode
+      .flatMap { _ -> Observable<Mutation> in
+        return .empty()
+      }
   }
 }

--- a/Tooda/Sources/Scenes/AddStock/AddStockReactor.swift
+++ b/Tooda/Sources/Scenes/AddStock/AddStockReactor.swift
@@ -90,12 +90,11 @@ extension AddStockReactor {
 // MARK: Seacrh Stock
 
 extension AddStockReactor {
+  // TODO: API Response -> Codable Entity -> Section Mutaion 전달 예정
   private func searchTextDidChanged(_ keyword: String) -> Observable<Mutation> {
     self.dependency.service.request(StockAPI.search(keyword: keyword))
       .asObservable()
       .mapString()
-      .debug()
-      // TestCode
       .flatMap { _ -> Observable<Mutation> in
         return .empty()
       }

--- a/Tooda/Sources/Scenes/AddStock/AddStockReactor.swift
+++ b/Tooda/Sources/Scenes/AddStock/AddStockReactor.swift
@@ -18,6 +18,7 @@ final class AddStockReactor: Reactor {
   
   enum Action {
     case searchTextDidChanged(String)
+    case dismiss
   }
   
   enum Mutation {
@@ -26,6 +27,7 @@ final class AddStockReactor: Reactor {
   
   struct Dependency {
     let completionRelay: PublishRelay<String>
+    let coordinator: AppCoordinatorType
   }
   
   struct State {
@@ -56,6 +58,8 @@ extension AddStockReactor {
         
         // TODO: Search API dependency 추가
         return .empty()
+      case .dismiss:
+        return self.dissmissView()
     }
   }
   
@@ -68,5 +72,19 @@ extension AddStockReactor {
     }
     
     return state
+  }
+}
+
+// MARK: Coordinator
+
+extension AddStockReactor {
+  private func dissmissView() -> Observable<Mutation> {
+    self.dependency.coordinator.close(
+      style: .dismiss,
+      animated: true,
+      completion: nil
+    )
+    
+    return .empty()
   }
 }

--- a/Tooda/Sources/Scenes/AddStock/AddStockViewController.swift
+++ b/Tooda/Sources/Scenes/AddStock/AddStockViewController.swift
@@ -100,7 +100,6 @@ final class AddStockViewController: BaseViewController<AddStockReactor> {
     
     // Action
     
-    // TODO: Reactor Action으로 변경
     self.closeBarButton.rx.tap
       .debounce(.milliseconds(500), scheduler: MainScheduler.instance)
       .map { Reactor.Action.dismiss }

--- a/Tooda/Sources/Scenes/AddStock/AddStockViewController.swift
+++ b/Tooda/Sources/Scenes/AddStock/AddStockViewController.swift
@@ -102,11 +102,10 @@ final class AddStockViewController: BaseViewController<AddStockReactor> {
     
     // TODO: Reactor Action으로 변경
     self.closeBarButton.rx.tap
-      .throttle(.milliseconds(500), scheduler: MainScheduler.instance)
-      .asDriver(onErrorJustReturn: ())
-      .drive(onNext: { [weak self] in
-        self?.dismiss(animated: true, completion: nil)
-      }).disposed(by: self.disposeBag)
+      .debounce(.milliseconds(500), scheduler: MainScheduler.instance)
+      .map { Reactor.Action.dismiss }
+      .bind(to: reactor.action)
+      .disposed(by: self.disposeBag)
     
     self.searchField.rx.text.orEmpty
       .debounce(.milliseconds(300), scheduler: MainScheduler.instance)


### PR DESCRIPTION
### 수정내역
- 종목 검색 화면에서 API 사용을 위해 NetworkingProtocol의 Dependency를 추가했어요.
- 종목 검색 텍스트 필드의 값이 입력되면 service 로직을 수행하고 response를 Observable String으로 전달받게끔 구현했어요.
- 닫기 버튼의 로직을 구현하기 위해 coordinator의 Dependency를 추가했어요.
- 닫기 버튼 입력 행위에 대한 Action을 바인딩하고 Mutation 로직을 구현했어요.

### 스크린샷
![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/19662529/140602362-5b35f306-05ab-4fd7-b5f9-5dd93ed63d87.gif)
 
