### PR TITLE
[UI] 종목 검색하기 화면에서 다음 버튼을 추가하고 키보드 영역에 붙여요.

### DIFF
--- a/Tooda/Sources/Common/Keyboard+LayoutGuide.swift
+++ b/Tooda/Sources/Common/Keyboard+LayoutGuide.swift
@@ -1,0 +1,167 @@
+//
+//  Keyboard+LayoutGuide.swift
+//  Tooda
+//
+//  Created by Lyine on 2021/11/14.
+//  Copyright © 2021 DTS. All rights reserved.
+//
+
+import UIKit
+
+internal class Keyboard {
+  static let shared = Keyboard()
+  var currentHeight: CGFloat = 0
+}
+
+extension UIView {
+  private enum Identifiers {
+    static var usingSafeArea = "KeyboardLayoutGuideUsingSafeArea"
+    static var notUsingSafeArea = "KeyboardLayoutGuide"
+  }
+  
+    /// A layout guide representing the inset for the keyboard.
+    /// Use this layout guide’s top anchor to create constraints pinning to the top of the keyboard or the bottom of safe area.
+  public var keyboardLayoutGuide: UILayoutGuide {
+    getOrCreateKeyboardLayoutGuide(identifier: Identifiers.usingSafeArea, usesSafeArea: true)
+  }
+  
+    /// A layout guide representing the inset for the keyboard.
+    /// Use this layout guide’s top anchor to create constraints pinning to the top of the keyboard or the bottom of the view.
+  public var keyboardLayoutGuideNoSafeArea: UILayoutGuide {
+    getOrCreateKeyboardLayoutGuide(identifier: Identifiers.notUsingSafeArea, usesSafeArea: false)
+  }
+  
+  private func getOrCreateKeyboardLayoutGuide(identifier: String, usesSafeArea: Bool) -> UILayoutGuide {
+    if let existing = layoutGuides.first(where: { $0.identifier == identifier }) {
+      return existing
+    }
+    let new = KeyboardLayoutGuide()
+    new.usesSafeArea = usesSafeArea
+    new.identifier = identifier
+    addLayoutGuide(new)
+    new.setUp()
+    return new
+  }
+}
+
+open class KeyboardLayoutGuide: UILayoutGuide {
+  public var usesSafeArea = true {
+    didSet {
+      updateButtomAnchor()
+    }
+  }
+  
+  private var bottomConstraint: NSLayoutConstraint?
+  
+  @available(*, unavailable)
+  public required init?(coder aDecoder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  public init(notificationCenter: NotificationCenter = NotificationCenter.default) {
+    super.init()
+      // Observe keyboardWillChangeFrame notifications
+    notificationCenter.addObserver(
+      self,
+      selector: #selector(keyboardWillChangeFrame(_:)),
+      name: UIResponder.keyboardWillChangeFrameNotification,
+      object: nil
+    )
+  }
+  
+  internal func setUp() {
+    guard let view = owningView else { return }
+    NSLayoutConstraint.activate(
+      [
+        heightAnchor.constraint(equalToConstant: Keyboard.shared.currentHeight),
+        leftAnchor.constraint(equalTo: view.leftAnchor),
+        rightAnchor.constraint(equalTo: view.rightAnchor),
+      ]
+    )
+    updateButtomAnchor()
+  }
+  
+  func updateButtomAnchor() {
+    if let bottomConstraint = bottomConstraint {
+      bottomConstraint.isActive = false
+    }
+    
+    guard let view = owningView else { return }
+    
+    let viewBottomAnchor: NSLayoutYAxisAnchor
+    if #available(iOS 11.0, *), usesSafeArea {
+      viewBottomAnchor = view.safeAreaLayoutGuide.bottomAnchor
+    } else {
+      viewBottomAnchor = view.bottomAnchor
+    }
+    
+    bottomConstraint = bottomAnchor.constraint(equalTo: viewBottomAnchor)
+    bottomConstraint?.isActive = true
+  }
+  
+  @objc
+  private func keyboardWillChangeFrame(_ note: Notification) {
+    if var height = note.keyboardHeight, let duration = note.animationDuration {
+      if #available(iOS 11.0, *), usesSafeArea, height > 0, let bottom = owningView?.safeAreaInsets.bottom {
+        height -= bottom
+      }
+      heightConstraint?.constant = height
+      if duration > 0.0 {
+        animate(note)
+      }
+      Keyboard.shared.currentHeight = height
+    }
+  }
+  
+  private func animate(_ note: Notification) {
+    if
+      let owningView = self.owningView,
+      isVisible(view: owningView)
+    {
+    self.owningView?.layoutIfNeeded()
+    } else {
+      UIView.performWithoutAnimation {
+        self.owningView?.layoutIfNeeded()
+      }
+    }
+  }
+}
+
+  // MARK: - Helpers
+extension UILayoutGuide {
+  internal var heightConstraint: NSLayoutConstraint? {
+    return owningView?.constraints.first {
+      $0.firstItem as? UILayoutGuide == self && $0.firstAttribute == .height
+    }
+  }
+}
+
+extension Notification {
+  var keyboardHeight: CGFloat? {
+    guard let keyboardFrame = userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue else {
+      return nil
+    }
+      // Weirdly enough UIKeyboardFrameEndUserInfoKey doesn't have the same behaviour
+      // in ios 10 or iOS 11 so we can't rely on v.cgRectValue.width
+    let screenHeight = UIApplication.shared.keyWindow?.bounds.height ?? UIScreen.main.bounds.height
+    return screenHeight - keyboardFrame.cgRectValue.minY
+  }
+  
+  var animationDuration: CGFloat? {
+    return self.userInfo?[UIResponder.keyboardAnimationDurationUserInfoKey] as? CGFloat
+  }
+}
+
+  // Credits to John Gibb for this nice helper :)
+  // https://stackoverflow.com/questions/1536923/determine-if-uiview-is-visible-to-the-user
+func isVisible(view: UIView) -> Bool {
+  func isVisible(view: UIView, inView: UIView?) -> Bool {
+    guard let inView = inView else { return true }
+    let viewFrame = inView.convert(view.bounds, from: view)
+    if viewFrame.intersects(inView.bounds) {
+      return isVisible(view: view, inView: inView.superview)
+    }
+    return false
+  }
+  return isVisible(view: view, inView: view.superview)
+}

--- a/Tooda/Sources/Common/Keyboard+LayoutGuide.swift
+++ b/Tooda/Sources/Common/Keyboard+LayoutGuide.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import SnapKit
 
 internal class Keyboard {
   static let shared = Keyboard()
@@ -51,7 +52,7 @@ open class KeyboardLayoutGuide: UILayoutGuide {
     }
   }
   
-  private var bottomConstraint: NSLayoutConstraint?
+  private var bottomConstraint: ConstraintItem?
   
   @available(*, unavailable)
   public required init?(coder aDecoder: NSCoder) {
@@ -71,32 +72,29 @@ open class KeyboardLayoutGuide: UILayoutGuide {
   
   internal func setUp() {
     guard let view = owningView else { return }
-    NSLayoutConstraint.activate(
-      [
-        heightAnchor.constraint(equalToConstant: Keyboard.shared.currentHeight),
-        leftAnchor.constraint(equalTo: view.leftAnchor),
-        rightAnchor.constraint(equalTo: view.rightAnchor),
-      ]
-    )
-    updateButtomAnchor()
+    
+    self.snp.makeConstraints {
+      $0.left.right.equalTo(view)
+      $0.height.equalTo(Keyboard.shared.currentHeight)
+    }
+    
+    self.updateButtomAnchor()
   }
   
   func updateButtomAnchor() {
-    if let bottomConstraint = bottomConstraint {
-      bottomConstraint.isActive = false
-    }
-    
     guard let view = owningView else { return }
-    
-    let viewBottomAnchor: NSLayoutYAxisAnchor
+        
     if #available(iOS 11.0, *), usesSafeArea {
-      viewBottomAnchor = view.safeAreaLayoutGuide.bottomAnchor
+      self.bottomConstraint = view.safeAreaLayoutGuide.snp.bottom
     } else {
-      viewBottomAnchor = view.bottomAnchor
+      self.bottomConstraint = view.snp.bottom
     }
     
-    bottomConstraint = bottomAnchor.constraint(equalTo: viewBottomAnchor)
-    bottomConstraint?.isActive = true
+    guard let bottomConstraint = self.bottomConstraint else { return }
+    
+    self.snp.makeConstraints {
+      $0.bottom.equalTo(bottomConstraint)
+    }
   }
   
   @objc

--- a/Tooda/Sources/Scenes/AddStock/AddStockViewController.swift
+++ b/Tooda/Sources/Scenes/AddStock/AddStockViewController.swift
@@ -22,6 +22,7 @@ final class AddStockViewController: BaseViewController<AddStockReactor> {
   
   private enum Font {
     static let searchField = TextStyle.body(color: .gray1)
+    static let nextButton = TextStyle.subTitleBold(color: .white)
     
   }
   
@@ -32,9 +33,11 @@ final class AddStockViewController: BaseViewController<AddStockReactor> {
   private enum Metric {
     static let verticalMargin: CGFloat = 16
     static let horizontalMargin: CGFloat = 14
+    static let nextButtonHeight: CGFloat = 48
   }
   
-    // MARK: Properties
+  // MARK: Properties
+  
   let dataSource: Section = Section(configureCell: { _, tableView, indexPath, item -> UITableViewCell in
     switch item {
       case .item(let reactor):
@@ -62,6 +65,24 @@ final class AddStockViewController: BaseViewController<AddStockReactor> {
     $0.allowsSelection = false
     $0.backgroundColor = .white
     $0.register(StockItemCell.self)
+  }
+  
+  private let buttonBackGroundView = UIView().then {
+    $0.backgroundColor = UIColor(type: .white)
+  }
+  
+  private let nextButton = UIButton(type: .system).then {
+    $0.setAttributedTitle(
+      "다음".styled(with: Font.nextButton),
+      for: .normal
+    )
+    
+    $0.backgroundColor = UIColor.gray3
+    $0.layer.cornerRadius = CGFloat(Metric.nextButtonHeight / 2)
+    $0.layer.shadowColor = UIColor(hex: "#43475314").withAlphaComponent(0.08).cgColor
+    $0.layer.shadowOffset = CGSize(width: 0, height: 12)
+    $0.layer.shadowOpacity = 1
+    $0.layer.shadowRadius = 12.0
   }
   
   private let closeBarButton = UIBarButtonItem(
@@ -132,9 +153,13 @@ final class AddStockViewController: BaseViewController<AddStockReactor> {
     
     self.view.backgroundColor = .white
     
-    self.view.addSubviews(searchFieldBackgroundView, tableView)
+    [searchFieldBackgroundView, tableView, buttonBackGroundView].forEach {
+      self.view.addSubview($0)
+    }
     
     self.searchFieldBackgroundView.addSubviews(searchField)
+    
+    self.buttonBackGroundView.addSubview(nextButton)
   }
   
   override func configureConstraints() {
@@ -155,7 +180,19 @@ final class AddStockViewController: BaseViewController<AddStockReactor> {
       $0.top.equalTo(searchFieldBackgroundView.snp.bottom).offset(9)
       $0.left.equalToSuperview().offset(Metric.horizontalMargin)
       $0.right.equalToSuperview().offset(-Metric.horizontalMargin)
-      $0.bottom.equalTo(self.view.safeAreaLayoutGuide.snp.bottom)
+      $0.bottom.equalTo(self.buttonBackGroundView.snp.top)
+    }
+    
+    buttonBackGroundView.snp.makeConstraints {
+      $0.left.right.equalToSuperview()
+      $0.bottom.equalTo(self.view.keyboardLayoutGuide.snp.top)
+    }
+    
+    nextButton.snp.makeConstraints {
+      $0.top.equalToSuperview().offset(16)
+      $0.left.right.equalToSuperview().inset(20)
+      $0.bottom.equalToSuperview().offset(-24)
+      $0.height.equalTo(Metric.nextButtonHeight)
     }
   }
   

--- a/Tooda/Sources/Scenes/AddStock/AddStockViewController.swift
+++ b/Tooda/Sources/Scenes/AddStock/AddStockViewController.swift
@@ -94,6 +94,11 @@ final class AddStockViewController: BaseViewController<AddStockReactor> {
     self.initializeNavigation()
   }
   
+  override func viewDidAppear(_ animated: Bool) {
+    super.viewDidAppear(animated)
+    self.focusTextField()
+  }
+  
   // MARK: Bind
   
   override func bind(reactor: Reactor) {
@@ -166,5 +171,9 @@ extension AddStockViewController {
   private func initializeNavigation() {
     self.navigationItem.title = "종목 기록하기"
     self.navigationItem.rightBarButtonItem = closeBarButton
+  }
+  
+  private func focusTextField() {
+    self.searchField.becomeFirstResponder()
   }
 }


### PR DESCRIPTION
### 수정내역 (필수)
- 키보드 영역에 컨텐츠를 붙이기 위해 써드파티 코드를 추가했어요. [참고](https://github.com/freshOS/KeyboardLayoutGuide)
- 종목 검색하기 화면에 다음 버튼을 추가하고 키보드 상단에 붙였어요.

### 스크린샷 (선택사항)
![ezgif com-gif-maker (3)](https://user-images.githubusercontent.com/19662529/141669614-6733d876-e0a9-4722-a942-32e5a7af5813.gif)
