### PR TITLE
[UI] 종목 변동률 선택 버튼과, 변동률 타입 선택 뷰를 추가했어요.

### DIFF
--- a/Tooda/Sources/Scenes/AddStock/View/RateButton.swift
+++ b/Tooda/Sources/Scenes/AddStock/View/RateButton.swift
@@ -1,0 +1,62 @@
+//
+//  RateButton.swift
+//  Tooda
+//
+//  Created by Lyine on 2021/11/26.
+//  Copyright © 2021 DTS. All rights reserved.
+//
+
+import UIKit
+
+final class RateButton: UIButton {
+  
+  private enum FontStyle {
+    static let disabledStyle = TextStyle.body(color: .gray2)
+  }
+  
+  private enum BorderStyle {
+    static let disabledColor = UIColor.gray2
+  }
+  
+  let stockState: StockChangeState
+  
+  override var isSelected: Bool {
+    willSet(newValue) {
+      self.buttonLayerDidChanged(by: newValue)
+    }
+  }
+  
+  init(stockState: StockChangeState) {
+    defer {
+      self.configure()
+    }
+    self.stockState = stockState
+    super.init(frame: .zero)
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  func configure(){
+    self.backgroundColor = .white
+    self.layer.cornerRadius = 10.0
+    self.layer.borderWidth = 1.0
+    self.layer.borderColor = BorderStyle.disabledColor.cgColor
+    
+    self.configureStyle()
+  }
+  
+  private func configureStyle() {
+    
+    let title = self.stockState.titleText
+    
+    self.setAttributedTitle(title.styled(with: FontStyle.disabledStyle), for: .normal)
+    
+    self.setAttributedTitle(title.styled(with: TextStyle.bodyBold(color: self.stockState.titleColor)), for: .selected)
+  }
+  
+  private func buttonLayerDidChanged(by isSelected: Bool) {
+    self.layer.borderColor = isSelected ? self.stockState.titleColor.cgColor : BorderStyle.disabledColor.cgColor
+  }
+}

--- a/Tooda/Sources/Scenes/AddStock/View/RateButton.swift
+++ b/Tooda/Sources/Scenes/AddStock/View/RateButton.swift
@@ -10,11 +10,11 @@ import UIKit
 
 final class RateButton: UIButton {
   
-  private enum FontStyle {
+  private enum Font {
     static let disabledStyle = TextStyle.body(color: .gray2)
   }
   
-  private enum BorderStyle {
+  private enum Const {
     static let disabledColor = UIColor.gray2
   }
   
@@ -42,7 +42,7 @@ final class RateButton: UIButton {
     self.backgroundColor = .white
     self.layer.cornerRadius = 10.0
     self.layer.borderWidth = 1.0
-    self.layer.borderColor = BorderStyle.disabledColor.cgColor
+    self.layer.borderColor = Const.disabledColor.cgColor
     
     self.configureStyle()
   }
@@ -51,12 +51,12 @@ final class RateButton: UIButton {
     
     let title = self.stockState.titleText
     
-    self.setAttributedTitle(title.styled(with: FontStyle.disabledStyle), for: .normal)
+    self.setAttributedTitle(title.styled(with: Font.disabledStyle), for: .normal)
     
     self.setAttributedTitle(title.styled(with: TextStyle.bodyBold(color: self.stockState.titleColor)), for: .selected)
   }
   
   private func buttonLayerDidChanged(by isSelected: Bool) {
-    self.layer.borderColor = isSelected ? self.stockState.titleColor.cgColor : BorderStyle.disabledColor.cgColor
+    self.layer.borderColor = isSelected ? self.stockState.titleColor.cgColor : Const.disabledColor.cgColor
   }
 }

--- a/Tooda/Sources/Scenes/AddStock/View/RateSelectView.swift
+++ b/Tooda/Sources/Scenes/AddStock/View/RateSelectView.swift
@@ -1,0 +1,105 @@
+//
+//  RateSelectView.swift
+//  Tooda
+//
+//  Created by Lyine on 2021/11/26.
+//  Copyright © 2021 DTS. All rights reserved.
+//
+
+import UIKit
+import RxSwift
+import RxCocoa
+import SnapKit
+
+final class RateSelectView: UIView {
+  
+  private(set) var didSetupConstraints = false
+  
+  var disposeBag: DisposeBag = DisposeBag()
+  
+  private enum Metric {
+    static let buttonWidth: CGFloat = 72.0
+  }
+  
+  private let stackView = UIStackView().then {
+    $0.axis = .horizontal
+    $0.distribution = .fillEqually
+    $0.alignment = .fill
+    $0.spacing = 8.0
+    $0.translatesAutoresizingMaskIntoConstraints = false
+  }
+  
+  private let riseButton = RateButton(stockState: .RISE)
+  private let evenButton = RateButton(stockState: .EVEN)
+  private let fallButton = RateButton(stockState: .FALL)
+  
+  var buttons: [RateButton] {
+    return [self.riseButton, self.evenButton, self.fallButton]
+  }
+  
+  override init(frame: CGRect) {
+    defer {
+      configureUI()
+    }
+    super.init(frame: frame)
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  override func updateConstraints() {
+    if !self.didSetupConstraints {
+      self.setupConstraints()
+      self.didSetupConstraints = true
+    }
+    super.updateConstraints()
+  }
+  
+  private func configureUI() {
+    self.addSubviews(stackView)
+    
+    buttons.forEach {
+      self.stackView.addArrangedSubview($0)
+    }
+  }
+  
+  private func setupConstraints() {
+    stackView.snp.makeConstraints {
+      $0.edges.equalToSuperview()
+    }
+    
+    riseButton.snp.makeConstraints {
+      $0.width.equalTo(Metric.buttonWidth)
+    }
+    
+    evenButton.snp.makeConstraints {
+      $0.width.equalTo(Metric.buttonWidth)
+    }
+    
+    fallButton.snp.makeConstraints {
+      $0.width.equalTo(Metric.buttonWidth)
+    }
+  }
+}
+
+  // MARK: - Extension
+
+extension Reactive where Base: RateSelectView {
+  var didSelectedChanged: Observable<StockChangeState> {
+    let selectedButton = Observable.from(
+      self.base.buttons.map { button in button.rx.tap.map { button.stockState } }
+    )
+      .merge()
+    
+    self.base.buttons.reduce(Disposables.create()) { disposable, button in
+      let subscription = selectedButton
+        .map { $0 == button.stockState }
+        .bind(to: button.rx.isSelected)
+      return Disposables.create(disposable, subscription)
+    }
+    .disposed(by: self.base.disposeBag)
+    
+    return selectedButton.asObservable()
+  }
+}

--- a/Tooda/Sources/Scenes/AddStock/View/RateSelectView.swift
+++ b/Tooda/Sources/Scenes/AddStock/View/RateSelectView.swift
@@ -90,7 +90,7 @@ extension Reactive where Base: RateSelectView {
     let selectedButton = Observable.from(
       self.base.buttons.map { button in button.rx.tap.map { button.stockState } }
     )
-      .merge()
+    .merge()
     
     self.base.buttons.reduce(Disposables.create()) { disposable, button in
       let subscription = selectedButton
@@ -100,6 +100,6 @@ extension Reactive where Base: RateSelectView {
     }
     .disposed(by: self.base.disposeBag)
     
-    return selectedButton.asObservable()
+    return selectedButton
   }
 }


### PR DESCRIPTION
### 수정내역 (필수)
- 종목 변동률 선택 버튼을 정의하고 UI 코드를 구현했어요.
- 변동률(상승, 유지, 하락)이 한꺼번에 들어있는 변동률 선택 뷰를 정의하고 UI를 구현했어요.
- 변동 타입 선택 뷰에 ViewController에서 선택된 버튼의 타입을 전달받기 위한 Reactive Extension 프로퍼티를 정의했어요.