### PR TITLE
[UI] 변동률 입력 화면의 기능을 구현했어요.

### DIFF
--- a/Tooda/Sources/Scenes/AddStock/StockRateInputReactor.swift
+++ b/Tooda/Sources/Scenes/AddStock/StockRateInputReactor.swift
@@ -23,6 +23,7 @@ final class StockRateInputReactor: Reactor {
   }
   
   struct State {
+    var name: String
     var selectedRate: StockChangeState = .EVEN
     var rateInput: Float = 0.0
     var buttonDidChanged: Bool = false
@@ -47,7 +48,7 @@ final class StockRateInputReactor: Reactor {
   ) {
     self.dependency = dependency
     self.payload = payload
-    initialState = State()
+    initialState = State(name: payload.name)
   }
   
   func mutate(action: Action) -> Observable<Mutation> {

--- a/Tooda/Sources/Scenes/AddStock/StockRateInputReactor.swift
+++ b/Tooda/Sources/Scenes/AddStock/StockRateInputReactor.swift
@@ -123,9 +123,9 @@ extension StockRateInputReactor {
     
     // TODO: 전달 Payload 데이터를 변경할 예정이에요.
     let noteStock = NoteStock(id: 0,
-                                   name: self.currentState.name,
-                                   change: self.currentState.selectedRate,
-                                   changeRate: changeRate)
+                              name: self.currentState.name,
+                              change: self.currentState.selectedRate,
+                              changeRate: changeRate)
     
     self.payload.completion.accept(noteStock)
     

--- a/Tooda/Sources/Scenes/AddStock/StockRateInputReactor.swift
+++ b/Tooda/Sources/Scenes/AddStock/StockRateInputReactor.swift
@@ -13,14 +13,19 @@ final class StockRateInputReactor: Reactor {
   enum Action {
     case closeButtonDidTapped
     case selectedStockDidChanged(StockChangeState)
+    case textFieldDidChanged(Float?)
   }
   
   enum Mutation {
     case selectedRateDidChanged(StockChangeState)
+    case addButtonDidChanged(Bool)
+    case rateDidChanged(Float)
   }
   
   struct State {
-    var selectedRate: StockChangeState?
+    var selectedRate: StockChangeState = .EVEN
+    var rateInput: Float = 0.0
+    var buttonDidChanged: Bool = false
   }
   
   struct Payload {
@@ -51,6 +56,8 @@ final class StockRateInputReactor: Reactor {
         return self.closeButtonDidTapped()
       case .selectedStockDidChanged(let rate):
         return self.selectedStockDidChanged(rate)
+      case .textFieldDidChanged(let rate):
+        return self.textFieldDidChanged(rate)
     }
   }
   
@@ -60,6 +67,10 @@ final class StockRateInputReactor: Reactor {
     switch mutation {
       case .selectedRateDidChanged(let rate):
         newState.selectedRate = rate
+      case .addButtonDidChanged(let enabled):
+        newState.buttonDidChanged = enabled
+      case .rateDidChanged(let rate):
+        newState.rateInput = rate
     }
     
     return newState
@@ -77,5 +88,16 @@ extension StockRateInputReactor {
   
   private func selectedStockDidChanged(_ state: StockChangeState) -> Observable<Mutation> {
     return .just(.selectedRateDidChanged(state))
+  }
+  
+  private func textFieldDidChanged(_ rate: Float?) -> Observable<Mutation> {
+    
+    let buttonDidEnabled = rate != nil
+    
+    guard let rateValue = rate else {
+      return .just(.addButtonDidChanged(buttonDidEnabled))
+    }
+    
+    return .concat([.just(.rateDidChanged(rateValue)), .just(.addButtonDidChanged(buttonDidEnabled))])
   }
 }

--- a/Tooda/Sources/Scenes/AddStock/StockRateInputReactor.swift
+++ b/Tooda/Sources/Scenes/AddStock/StockRateInputReactor.swift
@@ -12,14 +12,15 @@ import ReactorKit
 final class StockRateInputReactor: Reactor {
   enum Action {
     case closeButtonDidTapped
+    case selectedStockDidChanged(StockChangeState)
   }
   
   enum Mutation {
-    
+    case selectedRateDidChanged(StockChangeState)
   }
   
   struct State {
-    
+    var selectedRate: StockChangeState?
   }
   
   struct Payload {
@@ -48,11 +49,19 @@ final class StockRateInputReactor: Reactor {
     switch action {
       case .closeButtonDidTapped:
         return self.closeButtonDidTapped()
+      case .selectedStockDidChanged(let rate):
+        return self.selectedStockDidChanged(rate)
     }
   }
   
-  func reduce(state: State, mutation: Action) -> State {
+  func reduce(state: State, mutation: Mutation) -> State {
     var newState = state
+    
+    switch mutation {
+      case .selectedRateDidChanged(let rate):
+        newState.selectedRate = rate
+    }
+    
     return newState
   }
 }
@@ -64,5 +73,9 @@ extension StockRateInputReactor {
     self.dependency.coordinator.close(style: .pop, animated: true, completion: nil)
     
     return .empty()
+  }
+  
+  private func selectedStockDidChanged(_ state: StockChangeState) -> Observable<Mutation> {
+    return .just(.selectedRateDidChanged(state))
   }
 }

--- a/Tooda/Sources/Scenes/AddStock/StockRateInputReactor.swift
+++ b/Tooda/Sources/Scenes/AddStock/StockRateInputReactor.swift
@@ -11,6 +11,7 @@ import ReactorKit
 
 final class StockRateInputReactor: Reactor {
   enum Action {
+    case backbuttonDidTapped
     case closeButtonDidTapped
     case selectedStockDidChanged(StockChangeState)
     case textFieldDidChanged(Float?)
@@ -53,8 +54,8 @@ final class StockRateInputReactor: Reactor {
   
   func mutate(action: Action) -> Observable<Mutation> {
     switch action {
-      case .closeButtonDidTapped:
-        return self.closeButtonDidTapped()
+      case .backbuttonDidTapped:
+        return self.viewDidPop()
       case .selectedStockDidChanged(let rate):
         return self.selectedStockDidChanged(rate)
       case .textFieldDidChanged(let rate):
@@ -81,7 +82,7 @@ final class StockRateInputReactor: Reactor {
 // MARK: - Extensions
 
 extension StockRateInputReactor {
-  private func closeButtonDidTapped() -> Observable<Mutation> {
+  private func viewDidPop() -> Observable<Mutation> {
     self.dependency.coordinator.close(style: .pop, animated: true, completion: nil)
     
     return .empty()

--- a/Tooda/Sources/Scenes/AddStock/StockRateInputReactor.swift
+++ b/Tooda/Sources/Scenes/AddStock/StockRateInputReactor.swift
@@ -121,6 +121,7 @@ extension StockRateInputReactor {
     
     let changeRate = self.generateRateMutifiler() * (self.currentState.rateInput ?? 0.0)
     
+    // TODO: 전달 Payload 데이터를 변경할 예정이에요.
     let noteStock = NoteStock(id: 0,
                                    name: self.currentState.name,
                                    change: self.currentState.selectedRate,

--- a/Tooda/Sources/Scenes/AddStock/StockRateInputReactor.swift
+++ b/Tooda/Sources/Scenes/AddStock/StockRateInputReactor.swift
@@ -87,7 +87,7 @@ extension StockRateInputReactor {
   }
   
   private func selectedStockDidChanged(_ state: StockChangeState) -> Observable<Mutation> {
-    return .just(.selectedRateDidChanged(state))
+    return .concat([.just(.selectedRateDidChanged(state)), .just(.addButtonDidChanged(state == .EVEN))])
   }
   
   private func textFieldDidChanged(_ rate: Float?) -> Observable<Mutation> {

--- a/Tooda/Sources/Scenes/AddStock/StockRateInputViewController.swift
+++ b/Tooda/Sources/Scenes/AddStock/StockRateInputViewController.swift
@@ -53,8 +53,6 @@ class StockRateInputViewController: BaseViewController<StockRateInputReactor> {
   )
   
   private let titleLabel = UILabel().then {
-    // TODO: Mock 데이터 제거할 예정이에요.
-    $0.attributedText = "삼성전자".styled(with: Font.title)
     $0.numberOfLines = 0
   }
   
@@ -205,6 +203,14 @@ class StockRateInputViewController: BaseViewController<StockRateInputReactor> {
       .disposed(by: self.disposeBag)
     
     // State
+    
+    reactor.state
+      .map { $0.name }
+      .asDriver(onErrorJustReturn: "")
+      .drive(onNext: { [weak self] in
+        self?.titleLabel.attributedText = $0.styled(with: Font.title)
+      }).disposed(by: self.disposeBag)
+    
     reactor.state
       .map { $0.buttonDidChanged }
       .asDriver(onErrorJustReturn: false)

--- a/Tooda/Sources/Scenes/AddStock/StockRateInputViewController.swift
+++ b/Tooda/Sources/Scenes/AddStock/StockRateInputViewController.swift
@@ -187,6 +187,13 @@ class StockRateInputViewController: BaseViewController<StockRateInputReactor> {
       .map { Reactor.Action.backbuttonDidTapped }
       .bind(to: reactor.action)
       .disposed(by: self.disposeBag)
+    
+    self.addButton.rx.tap
+      .map { Reactor.Action.addButtonDidTapped }
+      .bind(to: reactor.action)
+      .disposed(by: self.disposeBag)
+    
+    self.closeBarButton.rx.tap
       .map { Reactor.Action.closeButtonDidTapped }
       .bind(to: reactor.action)
       .disposed(by: self.disposeBag)
@@ -201,6 +208,7 @@ class StockRateInputViewController: BaseViewController<StockRateInputReactor> {
     
     self.textField.rx.text.orEmpty
       .map { Float($0) }
+      .distinctUntilChanged()
       .map { Reactor.Action.textFieldDidChanged($0) }
       .bind(to: reactor.action)
       .disposed(by: self.disposeBag)
@@ -216,6 +224,7 @@ class StockRateInputViewController: BaseViewController<StockRateInputReactor> {
     
     reactor.state
       .map { $0.buttonDidChanged }
+      .distinctUntilChanged()
       .asDriver(onErrorJustReturn: false)
       .drive(onNext: { [weak self] in
         self?.addButtonDidChanged($0)
@@ -223,6 +232,7 @@ class StockRateInputViewController: BaseViewController<StockRateInputReactor> {
     
     reactor.state
       .map { $0.selectedRate == .EVEN }
+      .distinctUntilChanged()
       .asDriver(onErrorJustReturn: false)
       .drive(onNext: { [weak self] in
         self?.textFieldVisiblityDidChanged(by: $0)
@@ -254,7 +264,6 @@ extension StockRateInputViewController {
   private func textFieldDidHidden() {
     self.textFieldBackgroundView.isHidden = true
     self.percentLabel.isHidden = true
-    self.textField.resignFirstResponder()
   }
   
   private func textFieldDidShow() {

--- a/Tooda/Sources/Scenes/AddStock/StockRateInputViewController.swift
+++ b/Tooda/Sources/Scenes/AddStock/StockRateInputViewController.swift
@@ -211,6 +211,13 @@ class StockRateInputViewController: BaseViewController<StockRateInputReactor> {
       .drive(onNext: { [weak self] in
         self?.addButtonDidChanged($0)
       }).disposed(by: self.disposeBag)
+    
+    reactor.state
+      .map { $0.selectedRate == .EVEN }
+      .asDriver(onErrorJustReturn: false)
+      .drive(onNext: { [weak self] in
+        self?.textFieldVisiblityDidChanged(by: $0)
+      }).disposed(by: self.disposeBag)
   }
   
   @objc
@@ -229,5 +236,20 @@ extension StockRateInputViewController {
   
   private func addButtonDidChanged(_ isEnabled: Bool) {
     self.addButton.isEnabled = isEnabled
+  }
+  
+  private func textFieldVisiblityDidChanged(by isEven: Bool) {
+    isEven ? textFieldDidHidden() : textFieldDidShow()
+  }
+  
+  private func textFieldDidHidden() {
+    self.textFieldBackgroundView.isHidden = true
+    self.percentLabel.isHidden = true
+    self.textField.resignFirstResponder()
+  }
+  
+  private func textFieldDidShow() {
+    self.textFieldBackgroundView.isHidden = false
+    self.percentLabel.isHidden = false
   }
 }

--- a/Tooda/Sources/Scenes/AddStock/StockRateInputViewController.swift
+++ b/Tooda/Sources/Scenes/AddStock/StockRateInputViewController.swift
@@ -129,7 +129,7 @@ class StockRateInputViewController: BaseViewController<StockRateInputReactor> {
     }
     
     textField.snp.makeConstraints {
-      $0.edges.equalToSuperview().inset(UIEdgeInsets(top: 11, left: 14, bottom: 11, right: 14))
+      $0.edges.equalToSuperview().inset(UIEdgeInsets(horizontal: 14, vertical: 11))
       $0.height.equalTo(23)
     }
     

--- a/Tooda/Sources/Scenes/AddStock/StockRateInputViewController.swift
+++ b/Tooda/Sources/Scenes/AddStock/StockRateInputViewController.swift
@@ -184,6 +184,9 @@ class StockRateInputViewController: BaseViewController<StockRateInputReactor> {
       .asObservable()
       .flatMap { [weak self] _ -> Observable<Void> in
         return self?.configureBackBarButtonItemIfNeeded() ?? .empty() }
+      .map { Reactor.Action.backbuttonDidTapped }
+      .bind(to: reactor.action)
+      .disposed(by: self.disposeBag)
       .map { Reactor.Action.closeButtonDidTapped }
       .bind(to: reactor.action)
       .disposed(by: self.disposeBag)

--- a/Tooda/Sources/Scenes/AddStock/StockRateInputViewController.swift
+++ b/Tooda/Sources/Scenes/AddStock/StockRateInputViewController.swift
@@ -155,7 +155,8 @@ class StockRateInputViewController: BaseViewController<StockRateInputReactor> {
     self.rateButtonStackView.rx.didSelectedChanged
       .asObservable()
       .distinctUntilChanged()
-      .subscribe()
+      .map { Reactor.Action.selectedStockDidChanged($0) }
+      .bind(to: reactor.action)
       .disposed(by: self.disposeBag)
   }
   

--- a/Tooda/Sources/Scenes/AddStock/StockRateInputViewController.swift
+++ b/Tooda/Sources/Scenes/AddStock/StockRateInputViewController.swift
@@ -73,6 +73,7 @@ class StockRateInputViewController: BaseViewController<StockRateInputReactor> {
   
   private lazy var textField = UITextField().then {
     $0.addTarget(self, action: #selector(textFieldDidChange), for: .editingChanged)
+    $0.keyboardType = .numberPad
     $0.placeholder = "상승률/하락률"
   }
   

--- a/Tooda/Sources/Scenes/AddStock/View/RateSelectView.swift
+++ b/Tooda/Sources/Scenes/AddStock/View/RateSelectView.swift
@@ -30,7 +30,9 @@ final class RateSelectView: UIView {
   }
   
   private let riseButton = RateButton(stockState: .RISE)
-  private let evenButton = RateButton(stockState: .EVEN)
+  private let evenButton = RateButton(stockState: .EVEN).then {
+    $0.isSelected = true
+  }
   private let fallButton = RateButton(stockState: .FALL)
   
   var buttons: [RateButton] {


### PR DESCRIPTION
### 수정내역 (필수)
- 뒤로가기 버튼 기능을 구현했어요.
- "추가하기 버튼" UI를 추가하고 기능을 구현했어요.
- 유지 버튼을 누르면 텍스트 필드 영역과 퍼센트 레이블을 숨김처리하고 추가하기 버튼을 활성화해요.
- 텍스트필드의 값이 입력되면 토글된 상태와 입력 값에 따라 추가하기 버튼이 활성화 되어요.
- 추가하기 버튼이 활성화 되어있을 때, 버튼을 누르면 이전 화면에 데이터를 전달하고 화면을 내려줘요.

### 스크린샷 (선택사항)
|상승, 하강 상태|
|---------------------|
|![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/19662529/144733657-34f21fa6-4f80-425f-83ac-036855bf43fe.gif)|

|유지 상태|
|---------------------|
|![ezgif com-gif-maker](https://user-images.githubusercontent.com/19662529/144733692-708c09f2-51ce-4e5f-b5eb-0257c878fd19.gif)|

