### PR TITLE
[Domain] 노트 등록화면에서 추가된 종목의 정보를 볼 수 있어요.

### DIFF
--- a/Tooda/Sources/Entities/Note/NoteStock.swift
+++ b/Tooda/Sources/Entities/Note/NoteStock.swift
@@ -10,30 +10,30 @@ import Foundation
 import UIKit
 
 enum StockChangeState: String, Codable {
-	case RISE
-	case EVEN
-	case FALL
+	case rise
+	case even
+	case fall
 }
 
 extension StockChangeState {
   var titleText: String {
     switch self {
-      case .RISE:
+      case .rise:
         return "+ 상승"
-      case .EVEN:
+      case .even:
         return "유지"
-      case .FALL:
+      case .fall:
         return "- 하락"
     }
   }
     
   var titleColor: UIColor {
     switch self {
-      case .RISE:
+      case .rise:
         return UIColor.subRed
-      case .EVEN:
+      case .even:
         return UIColor.gray2
-      case .FALL:
+      case .fall:
         return UIColor.subBlue
     }
   }

--- a/Tooda/Sources/Scenes/AddStock/StockRateInputReactor.swift
+++ b/Tooda/Sources/Scenes/AddStock/StockRateInputReactor.swift
@@ -26,7 +26,7 @@ final class StockRateInputReactor: Reactor {
   
   struct State {
     var name: String
-    var selectedRate: StockChangeState = .EVEN
+    var selectedRate: StockChangeState = .even
     var rateInput: Float?
     var buttonDidChanged: Bool = true
   }
@@ -102,10 +102,10 @@ extension StockRateInputReactor {
   private func selectedStockDidChanged(_ state: StockChangeState) -> Observable<Mutation> {
     
     switch state {
-      case .RISE, .FALL:
+      case .rise, .fall:
         let addButtonEnabled = self.currentState.rateInput != nil
         return .concat([.just(.selectedRateDidChanged(state)), .just(.addButtonDidChanged(addButtonEnabled))])
-      case .EVEN:
+      case .even:
         return .concat([.just(.selectedRateDidChanged(state)), .just(.addButtonDidChanged(true))])
     }
   }
@@ -134,9 +134,9 @@ extension StockRateInputReactor {
   
   private func generateRateMutifiler() -> Float {
     switch self.currentState.selectedRate {
-      case .EVEN, .RISE:
+      case .even, .rise:
         return 1
-      case .FALL:
+      case .fall:
         return -1
     }
   }

--- a/Tooda/Sources/Scenes/AddStock/StockRateInputViewController.swift
+++ b/Tooda/Sources/Scenes/AddStock/StockRateInputViewController.swift
@@ -231,7 +231,7 @@ class StockRateInputViewController: BaseViewController<StockRateInputReactor> {
       }).disposed(by: self.disposeBag)
     
     reactor.state
-      .map { $0.selectedRate == .EVEN }
+      .map { $0.selectedRate == .even }
       .distinctUntilChanged()
       .asDriver(onErrorJustReturn: false)
       .drive(onNext: { [weak self] in

--- a/Tooda/Sources/Scenes/AddStock/View/RateSelectView.swift
+++ b/Tooda/Sources/Scenes/AddStock/View/RateSelectView.swift
@@ -29,11 +29,11 @@ final class RateSelectView: UIView {
     $0.translatesAutoresizingMaskIntoConstraints = false
   }
   
-  private let riseButton = RateButton(stockState: .RISE)
-  private let evenButton = RateButton(stockState: .EVEN).then {
+  private let riseButton = RateButton(stockState: .rise)
+  private let evenButton = RateButton(stockState: .even).then {
     $0.isSelected = true
   }
-  private let fallButton = RateButton(stockState: .FALL)
+  private let fallButton = RateButton(stockState: .fall)
   
   var buttons: [RateButton] {
     return [self.riseButton, self.evenButton, self.fallButton]

--- a/Tooda/Sources/Scenes/CreateNote/Cells/NoteStockCell.swift
+++ b/Tooda/Sources/Scenes/CreateNote/Cells/NoteStockCell.swift
@@ -16,6 +16,41 @@ class NoteStockCell: BaseTableViewCell, View {
 
   var disposeBag: DisposeBag = DisposeBag()
   
+  private enum Font {
+    static let title = TextStyle.body(color: .gray1)
+  }
+  
+    // MARK: UI Properties
+  
+  private let containerView = UIView().then {
+    $0.layer.borderColor = UIColor.gray4.cgColor
+    $0.layer.borderWidth = 1.0
+  }
+  
+  private let titleLabel = UILabel().then {
+    $0.numberOfLines = 1
+  }
+  
+  private let rateStackView = UIStackView().then {
+    $0.axis = .horizontal
+    $0.alignment = .center
+    $0.distribution = .fill
+    $0.spacing = 6.0
+    $0.translatesAutoresizingMaskIntoConstraints = false
+  }
+  
+  private let rateIndicatorView = UIView().then {
+    $0.layer.borderWidth = 1.0
+    $0.layer.cornerRadius = 12.0
+    $0.clipsToBounds = true
+  }
+  
+  private let rateIndicatorLabel = UILabel()
+  
+  private let ratePercentLabel = UILabel().then {
+    $0.numberOfLines = 1
+  }
+  
   // MARK: Cell Life Cycle
   
   override func prepareForReuse() {
@@ -24,6 +59,84 @@ class NoteStockCell: BaseTableViewCell, View {
   }
 
   func bind(reactor: Reactor) {
+    reactor.state.map { $0.payload }
+    .subscribeOn(MainScheduler.instance)
+    .subscribe(onNext: { [weak self] in
+      self?.configureCell($0)
+    })
+    .disposed(by: self.disposeBag)
+  }
+  
+  func configure(with reactor: Reactor) {
+    super.configure()
+    
+    self.reactor = reactor
+  }
+  
+  override func configureUI() {
+    super.configureUI()
+    
+    self.contentView.addSubviews(containerView)
+    
+    self.containerView.addSubviews(self.titleLabel, self.rateStackView)
+    
+    self.rateStackView.addArrangedSubview(self.rateIndicatorView)
+    self.rateStackView.addArrangedSubview(self.ratePercentLabel)
+    
+    self.rateIndicatorView.addSubview(self.rateIndicatorLabel)
+  }
+  
+  override func setupConstraints() {
+    super.setupConstraints()
+    
+    self.containerView.snp.makeConstraints {
+      $0.edges.equalToSuperview().inset(UIEdgeInsets(top: 10, left: 0, bottom: 0, right: 0))
+    }
+    
+    self.titleLabel.snp.makeConstraints {
+      $0.top.equalToSuperview().offset(11)
+      $0.left.equalToSuperview().offset(14)
+      $0.bottom.equalToSuperview().offset(-14)
+    }
+    
+    self.rateStackView.snp.makeConstraints {
+      $0.centerY.equalTo(self.titleLabel)
+      $0.right.equalToSuperview().offset(-14)
+      $0.left.greaterThanOrEqualTo(self.titleLabel.snp.right).offset(14)
+    }
+    
+    self.rateIndicatorLabel.snp.makeConstraints {
+      $0.edges.equalToSuperview().inset(UIEdgeInsets(top: 3, left: 7, bottom: 2, right: 7))
+    }
+  }
+}
 
+  // MARK: - Extensions
+
+extension NoteStockCell {
+  private func configureCell(_ payload: Reactor.Payload) {
+    self.titleLabel.attributedText = payload.name.styled(with: Font.title)
+    
+    let rateValue = "\(payload.rate)%"
+    
+    self.ratePercentLabel.attributedText = rateValue.styled(with: TextStyle.bodyBold(color: payload.state.titleColor))
+    
+    var attributeText = NSAttributedString()
+    var color: UIColor
+    
+    switch payload.state {
+      case .rise:
+        color = UIColor.subRed
+        attributeText = "상승".styled(with: TextStyle.captionBold(color: color))
+      case .even:
+        color = UIColor.gray1
+        attributeText = "유지".styled(with: TextStyle.captionBold(color: color))
+      case .fall:
+        color = UIColor.subBlue
+        attributeText = "하락".styled(with: TextStyle.captionBold(color: color))
+    }
+    
+    self.rateIndicatorLabel.attributedText = attributeText
+    self.rateIndicatorView.layer.borderColor = color.cgColor
   }
 }

--- a/Tooda/Sources/Scenes/CreateNote/Cells/NoteStockCell.swift
+++ b/Tooda/Sources/Scenes/CreateNote/Cells/NoteStockCell.swift
@@ -95,14 +95,14 @@ class NoteStockCell: BaseTableViewCell, View {
     
     self.titleLabel.snp.makeConstraints {
       $0.top.equalToSuperview().offset(11)
-      $0.left.equalToSuperview().offset(14)
+      $0.leading.equalToSuperview().offset(14)
       $0.bottom.equalToSuperview().offset(-14)
     }
     
     self.rateStackView.snp.makeConstraints {
       $0.centerY.equalTo(self.titleLabel)
-      $0.right.equalToSuperview().offset(-14)
-      $0.left.greaterThanOrEqualTo(self.titleLabel.snp.right).offset(14)
+      $0.trailing.equalToSuperview().offset(-14)
+      $0.leading.greaterThanOrEqualTo(self.titleLabel.snp.trailing).offset(14)
     }
     
     self.rateIndicatorLabel.snp.makeConstraints {

--- a/Tooda/Sources/Scenes/CreateNote/Cells/Reactors/NoteStockCellReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/Cells/Reactors/NoteStockCellReactor.swift
@@ -41,3 +41,20 @@ final class NoteStockCellReactor: Reactor {
     return newState
   }
 }
+
+  // MARK: Extensions
+
+extension NoteStockCellReactor.Payload {
+  var state: StockChangeState {
+    let value = self.rate
+    
+    switch value {
+      case let _ where value > 0:
+        return .rise
+      case let _ where value == 0:
+        return .even
+      default:
+        return .fall
+    }
+  }
+}

--- a/Tooda/Sources/Scenes/CreateNote/Cells/Reactors/NoteStockCellReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/Cells/Reactors/NoteStockCellReactor.swift
@@ -18,13 +18,18 @@ final class NoteStockCellReactor: Reactor {
   }
 
   struct State {
-
+    var payload: Payload
+  }
+  
+  struct Payload {
+    var name: String
+    var rate: Float
   }
 
   let initialState: State
 
-  init() {
-    initialState = State()
+  init(payload: Payload) {
+    initialState = State(payload: payload)
   }
 
   func mutate(action: Action) -> Observable<Mutation> {

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
@@ -55,6 +55,10 @@ class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
       cell.selectionStyle = .none
       
       return cell
+    case .stock(let reactor):
+        let cell = tableView.dequeue(NoteStockCell.self, indexPath: indexPath)
+        cell.configure(with: reactor)
+        return cell
     default:
       return UITableViewCell()
     }
@@ -74,6 +78,7 @@ class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
     $0.register(NoteContentCell.self)
     $0.register(EmptyNoteStockCell.self)
     $0.register(NoteImageCell.self)
+    $0.register(NoteStockCell.self)
   }
 
   // MARK: Initialize

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -196,8 +196,11 @@ extension CreateNoteViewReactor {
 
 extension CreateNoteViewReactor {
   private func makeStockSectionItem(_ stock: NoteStock) -> Observable<Mutation> {
-    // TODO: stock 정보를 Cell에 업데이트 해줘요.
-    let reator = NoteStockCellReactor()
+    let reator = NoteStockCellReactor(
+      payload: .init(name: stock.name,
+                     rate: stock.changeRate ?? 0.0)
+    )
+    
     let sectionItem = NoteSectionItem.stock(reator)
     
     return .just(.fetchStockSection(sectionItem))

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -35,12 +35,14 @@ final class CreateNoteViewReactor: Reactor {
     case didSelectedImageItem(IndexPath)
     case uploadImage(Data)
     case showAddStockView
+    case stockItemDidAdded(NoteStock)
   }
 
   enum Mutation {
     case initializeForm([NoteSection])
     case present(ViewPresentType)
     case fetchImageSection(NoteSectionItem)
+    case fetchStockSection(NoteSectionItem)
   }
 
   struct State: Then {
@@ -73,6 +75,8 @@ final class CreateNoteViewReactor: Reactor {
     case .showAddStockView:
       self.dependency.coordinator.transition(to: .addStock(completion: self.addStockCompletionRelay), using: .modal, animated: true, completion: nil)
       return .empty()
+    case .stockItemDidAdded(let stock):
+      return self.makeStockSectionItem(stock)
     default:
       return .empty()
     }
@@ -92,9 +96,15 @@ final class CreateNoteViewReactor: Reactor {
       newState.presentType = type
     case .fetchImageSection(let sectionItem):
       newState.sections[NoteSection.Identity.image.rawValue].items = [sectionItem]
+    case .fetchStockSection(let sectionItem):
+      newState.sections[NoteSection.Identity.stock.rawValue].items.append(sectionItem)
     }
 
     return newState
+  }
+  
+  func transform(action: Observable<Action>) -> Observable<Action> {
+    return Observable.merge(action, self.addStockCompletionRelay.map { Action.stockItemDidAdded($0) })
   }
 
   private func makeSections() -> [NoteSection] {
@@ -179,6 +189,18 @@ extension CreateNoteViewReactor {
     imageCellReactor.action.onNext(.addImage(imageURL))
 
     return .empty()
+  }
+}
+
+// MARK: Add Stock Items
+
+extension CreateNoteViewReactor {
+  private func makeStockSectionItem(_ stock: NoteStock) -> Observable<Mutation> {
+    // TODO: stock 정보를 Cell에 업데이트 해줘요.
+    let reator = NoteStockCellReactor()
+    let sectionItem = NoteSectionItem.stock(reator)
+    
+    return .just(.fetchStockSection(sectionItem))
   }
 }
 


### PR DESCRIPTION
### 수정내역 (필수)
- 노트의 종목 셀 UI를 구현했어요.
- 노트 종목 셀 Reactor에 Payload 구조체를 정의하고 state에 멤버변수로 추가했어요.
- 종목 추가 하기 화면에서 추가 버튼을 누르면 입력된 정보를 바탕으로 노트 등록하기 화면에 새로운 SectionItem을 추가할 수 있게 Reactor에 localPublishRelay를 정의해주고, Transform 메소드를 통해 Action과 합성해주는 로직을 추가했어요.
- 노트 등록 화면에서 DataSource 클로저 블록에 노트 종목 셀과 관련된 case를 구현하고, tableView에 종목 셀을 등록시켰어요.

### 스크린샷 (선택사항)
<img src="https://user-images.githubusercontent.com/19662529/145666902-22fcbe3d-d91e-4f15-9b90-350c6b629b29.png" width=320>

