### PR TITLE
[UI] 노트 등록 화면에서 종목 아이템을 스와이프하면 수정, 삭제 UI를 볼 수 있어요.

### DIFF
--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
@@ -270,7 +270,7 @@ extension CreateNoteViewController {
       case .stock:
         let delete = self.deleteCellAction(at: indexPath)
         
-        let edit = self.deleteCellAction(at: indexPath)
+        let edit = self.editCellAction(at: indexPath)
         
         let swipeActionConfig = UISwipeActionsConfiguration(actions: [delete, edit])
         swipeActionConfig.performsFirstActionWithFullSwipe = false

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
@@ -258,22 +258,43 @@ extension CreateNoteViewController: UIImagePickerControllerDelegate, UINavigatio
 
 extension CreateNoteViewController: UITableViewDelegate {
   func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+    return self.generateEditableSwipeConfigure(at: indexPath)
+  }
+}
+
+// MARK: - Generate UISwipeActionsConfiguration
+
+extension CreateNoteViewController {
+  private func generateEditableSwipeConfigure(at indexPath: IndexPath) -> UISwipeActionsConfiguration? {
     switch dataSource[indexPath] {
       case .stock:
-        let delete = UIContextualAction(style: .destructive, title: "삭제") { _, _, completionHandler in
-          print("아이템을 제거해요: \(indexPath)")
-          completionHandler(true)
-        }
+        let delete = self.deleteCellAction(at: indexPath)
         
-        let rename = UIContextualAction(style: .normal, title: "수정") { _, _, completionHandler in
-          print("아이템을 수정해요: \(indexPath)")
-          completionHandler(true)
-        }
-        let swipeActionConfig = UISwipeActionsConfiguration(actions: [delete, rename])
+        let edit = self.deleteCellAction(at: indexPath)
+        
+        let swipeActionConfig = UISwipeActionsConfiguration(actions: [delete, edit])
         swipeActionConfig.performsFirstActionWithFullSwipe = false
         return swipeActionConfig
       default:
         return nil
     }
+  }
+  
+  private func deleteCellAction(at indexPath: IndexPath) -> UIContextualAction {
+    let action = UIContextualAction(style: .destructive, title: "삭제") { _, _, completionHandler in
+      print("아이템을 제거해요: \(indexPath)")
+      completionHandler(true)
+    }
+    
+    return action
+  }
+  
+  private func editCellAction(at indexPath: IndexPath) -> UIContextualAction {
+    let action = UIContextualAction(style: .normal, title: "수정") { _, _, completionHandler in
+      print("아이템을 수정해요: \(indexPath)")
+      completionHandler(true)
+    }
+    
+    return action
   }
 }

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
@@ -62,18 +62,20 @@ class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
     default:
       return UITableViewCell()
     }
-  })
+  }, canEditRowAtIndexPath: { _, _ in true })
 
 
   // MARK: UI-Properties
 
-  let tableView = UITableView().then {
+  private lazy var tableView = UITableView().then {
     $0.separatorStyle = .none
     $0.backgroundColor = .white
     $0.estimatedRowHeight = UITableView.automaticDimension
     $0.alwaysBounceHorizontal = false
     
     $0.allowsSelection = false
+    
+    $0.delegate = self
 
     $0.register(NoteContentCell.self)
     $0.register(EmptyNoteStockCell.self)
@@ -249,5 +251,29 @@ extension CreateNoteViewController: UIImagePickerControllerDelegate, UINavigatio
     }
     
     picker.dismiss(animated: true, completion: nil)
+  }
+}
+
+// MARK: - UITableView Delegate
+
+extension CreateNoteViewController: UITableViewDelegate {
+  func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+    switch dataSource[indexPath] {
+      case .stock:
+        let delete = UIContextualAction(style: .destructive, title: "삭제") { _, _, completionHandler in
+          print("아이템을 제거해요: \(indexPath)")
+          completionHandler(true)
+        }
+        
+        let rename = UIContextualAction(style: .normal, title: "수정") { _, _, completionHandler in
+          print("아이템을 수정해요: \(indexPath)")
+          completionHandler(true)
+        }
+        let swipeActionConfig = UISwipeActionsConfiguration(actions: [delete, rename])
+        swipeActionConfig.performsFirstActionWithFullSwipe = false
+        return swipeActionConfig
+      default:
+        return nil
+    }
   }
 }

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
@@ -282,7 +282,6 @@ extension CreateNoteViewController {
   
   private func deleteCellAction(at indexPath: IndexPath) -> UIContextualAction {
     let action = UIContextualAction(style: .destructive, title: "삭제") { _, _, completionHandler in
-      print("아이템을 제거해요: \(indexPath)")
       completionHandler(true)
     }
     
@@ -291,7 +290,6 @@ extension CreateNoteViewController {
   
   private func editCellAction(at indexPath: IndexPath) -> UIContextualAction {
     let action = UIContextualAction(style: .normal, title: "수정") { _, _, completionHandler in
-      print("아이템을 수정해요: \(indexPath)")
       completionHandler(true)
     }
     


### PR DESCRIPTION
### 수정내역 (필수)
- tableView delegate를 사용하기 위해 tableView 선언 타입을 변경했어요.
- 셀의 수정,삭제 UI를 표현하기 위해 DataSource에서 canEditRowAtIndexPath를 추가했어요.
- 셀 수정과 관련된 delegate 메소드를 구현했어요.

### 스크린샷 (선택사항)
![ezgif com-gif-maker (3)](https://user-images.githubusercontent.com/19662529/145696062-f34eeea1-26d2-4529-a6d2-1d8a044b174c.gif)

### Todo
- [ ] : 수정 버튼을 누르면 변동률을 변경할 수 있게 present로 새 창을 띄워요.
- [ ] : 삭제 버튼을 누르면 Alert과 함께 삭제 기능을 구현해요.
