### PR TITLE
[UI] 홈화면에 표시될 노트 등록 안내 화면을 구현했어요.

### DIFF
--- a/Tooda/Sources/Common/Extensions/UIView+Extension.swift
+++ b/Tooda/Sources/Common/Extensions/UIView+Extension.swift
@@ -13,3 +13,16 @@ extension UIView {
     subviews.forEach(addSubview)
   }
 }
+
+extension UIView {
+  func generateGradient(colors: [UIColor], locations: [NSNumber] = [0, 1], startPoint: CGPoint = CGPoint(x: 0.5, y: 0.0), endPoint: CGPoint = CGPoint(x: 0.5, y: 1.0)) -> CAGradientLayer {
+    let gradient: CAGradientLayer = CAGradientLayer()
+    gradient.frame = self.bounds
+    gradient.colors = colors.map { $0.cgColor }
+    gradient.startPoint = startPoint
+    gradient.endPoint = endPoint
+    gradient.locations = locations
+    
+    return gradient
+  }
+}

--- a/Tooda/Sources/Common/Extensions/UIView+Extension.swift
+++ b/Tooda/Sources/Common/Extensions/UIView+Extension.swift
@@ -26,3 +26,13 @@ extension UIView {
     return gradient
   }
 }
+
+extension UIView {
+  func configureShadow(color: UIColor, radius: CGFloat, opacity: Float, offset: CGSize) {
+    self.layer.masksToBounds = false
+    self.layer.shadowColor = color.cgColor
+    self.layer.shadowOpacity = opacity
+    self.layer.shadowOffset = offset
+    self.layer.shadowRadius = radius
+  }
+}

--- a/Tooda/Sources/Scenes/CreateNote/View/CreateGuideView.swift
+++ b/Tooda/Sources/Scenes/CreateNote/View/CreateGuideView.swift
@@ -18,6 +18,15 @@ final class CreateGuideView: UIView {
     static let description = TextStyle.body(color: .gray3)
   }
   
+  private enum Constants {
+    static let gradientGrayColor = UIColor(hex: "#EDF0F0")
+    static let shadowColor = UIColor(hex: "#394B44")
+  }
+  
+  private let contentView = UIView().then {
+    $0.layer.masksToBounds = false
+  }
+  
   private let titleLabel = UILabel().then {
     $0.textAlignment = .center
     $0.numberOfLines = 1
@@ -56,26 +65,23 @@ final class CreateGuideView: UIView {
   
   private func configureUI() {
     
-    self.do {
-      $0.backgroundColor = .white
-      $0.layer.cornerRadius = 16
-      $0.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
-      $0.layer.shadowColor = UIColor(hex: "#394B44").withAlphaComponent(0.12).cgColor
-      $0.layer.shadowOffset = CGSize(width: 0, height: 8)
-      $0.layer.shadowOpacity = 1
-      $0.layer.shadowRadius = 40.0
-    }
-    
     self.titleLabel.do {
       $0.attributedText = Date().string(.dot).styled(with: Font.date)
     }
     
-    self.addSubviews(titleLabel, descriptionContainerView)
+    self.addSubview(contentView)
+    
+    self.contentView.addSubviews(titleLabel, descriptionContainerView)
     
     self.descriptionContainerView.addSubview(descriptionLabel)
   }
   
   private func setupConstraints() {
+    
+    contentView.snp.makeConstraints {
+      $0.edges.equalToSuperview()
+    }
+    
     titleLabel.snp.makeConstraints {
       $0.top.equalToSuperview().offset(20)
       $0.centerX.equalToSuperview()
@@ -90,5 +96,39 @@ final class CreateGuideView: UIView {
     descriptionLabel.snp.makeConstraints {
       $0.edges.equalToSuperview().inset(UIEdgeInsets(top: 12, left: 14, bottom: 10, right: 14))
     }
+  }
+  
+  override func layoutSubviews() {
+    super.layoutSubviews()
+    
+    self.applyGradientAndShadow(self.contentView)
+  }
+  
+  private func applyGradientAndShadow(_ view: UIView) {
+    view.do {
+      let gradient = $0.generateGradient(colors: [UIColor.white, Constants.gradientGrayColor])
+      
+      gradient.cornerRadius = 16
+      gradient.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
+      
+      gradient.makeShadow(color: Constants.shadowColor.withAlphaComponent(0.12),
+                          radius: 40,
+                          opacity: 1,
+                          offset: CGSize(width: 0, height: 8))
+      
+      $0.layer.insertSublayer(gradient, at: 0)
+    }
+  }
+}
+
+// MARK: - Extensions
+
+private extension CALayer {
+  func makeShadow(color: UIColor, radius: CGFloat, opacity: Float, offset: CGSize) {
+    self.masksToBounds = false
+    self.shadowColor = color.cgColor
+    self.shadowOpacity = opacity
+    self.shadowOffset = offset
+    self.shadowRadius = radius
   }
 }

--- a/Tooda/Sources/Scenes/CreateNote/View/CreateGuideView.swift
+++ b/Tooda/Sources/Scenes/CreateNote/View/CreateGuideView.swift
@@ -10,6 +10,10 @@ import UIKit
 import Then
 import SnapKit
 
+protocol CreateNoteGuideViewDelegate: AnyObject {
+  func contentDidTapped()
+}
+
 final class CreateGuideView: UIView {
   
   private(set) var didSetupConstraints = false
@@ -24,7 +28,9 @@ final class CreateGuideView: UIView {
     static let shadowColor = UIColor(hex: "#394B44")
   }
   
-  private let contentView = UIView().then {
+  weak var delegate: CreateNoteGuideViewDelegate?
+  
+  let contentView = UIView().then {
     $0.layer.masksToBounds = false
   }
   
@@ -48,6 +54,7 @@ final class CreateGuideView: UIView {
   override init(frame: CGRect) {
     defer {
       self.configureUI()
+      self.configureGesture()
     }
     super.init(frame: frame)
   }
@@ -103,6 +110,16 @@ final class CreateGuideView: UIView {
     super.layoutSubviews()
     
     self.applyGradientAndShadow(self.contentView)
+  }
+  
+  private func configureGesture() {
+    let tapGesture = UITapGestureRecognizer(target: self, action: #selector(contentViewDidTapped))
+    self.contentView.addGestureRecognizer(tapGesture)
+  }
+  
+  @objc
+  private func contentViewDidTapped(_ sender: Any?) {
+    self.delegate?.contentDidTapped()
   }
   
   private func applyGradientAndShadow(_ view: UIView) {

--- a/Tooda/Sources/Scenes/CreateNote/View/CreateGuideView.swift
+++ b/Tooda/Sources/Scenes/CreateNote/View/CreateGuideView.swift
@@ -1,0 +1,94 @@
+//
+//  CreateGuideView.swift
+//  Tooda
+//
+//  Created by Lyine on 2021/12/12.
+//  Copyright © 2021 DTS. All rights reserved.
+//
+
+import UIKit
+import Then
+
+final class CreateGuideView: UIView {
+  
+  private(set) var didSetupConstraints = false
+  
+  private enum Font {
+    static let date = TextStyle.subTitle(color: .gray1)
+    static let description = TextStyle.body(color: .gray3)
+  }
+  
+  private let titleLabel = UILabel().then {
+    $0.textAlignment = .center
+    $0.numberOfLines = 1
+  }
+  
+  private let descriptionContainerView = UIView().then {
+    $0.backgroundColor = .white
+    $0.layer.cornerRadius = 8.0
+    $0.layer.borderColor = UIColor.gray4.cgColor
+    $0.layer.borderWidth = 1.0
+  }
+  
+  private let descriptionLabel = UILabel().then {
+    $0.attributedText = "✍️ 오늘의 투자 기록을 적어보세요.".styled(with: Font.description)
+    $0.numberOfLines = 1
+  }
+  
+  override init(frame: CGRect) {
+    defer {
+      self.configureUI()
+    }
+    super.init(frame: frame)
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  override func updateConstraints() {
+    if !self.didSetupConstraints {
+      self.setupConstraints()
+      self.didSetupConstraints = true
+    }
+    super.updateConstraints()
+  }
+  
+  private func configureUI() {
+    
+    self.do {
+      $0.backgroundColor = .white
+      $0.layer.cornerRadius = 16
+      $0.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
+      $0.layer.shadowColor = UIColor(hex: "#394B44").withAlphaComponent(0.12).cgColor
+      $0.layer.shadowOffset = CGSize(width: 0, height: 8)
+      $0.layer.shadowOpacity = 1
+      $0.layer.shadowRadius = 40.0
+    }
+    
+    self.titleLabel.do {
+      $0.attributedText = Date().string(.dot).styled(with: Font.date)
+    }
+    
+    self.addSubviews(titleLabel, descriptionContainerView)
+    
+    self.descriptionContainerView.addSubview(descriptionLabel)
+  }
+  
+  private func setupConstraints() {
+    titleLabel.snp.makeConstraints {
+      $0.top.equalToSuperview().offset(20)
+      $0.centerX.equalToSuperview()
+    }
+    
+    descriptionContainerView.snp.makeConstraints {
+      $0.top.equalTo(self.titleLabel.snp.bottom).offset(13)
+      $0.leading.trailing.equalToSuperview().inset(20)
+      $0.bottom.equalToSuperview().offset(-61)
+    }
+    
+    descriptionLabel.snp.makeConstraints {
+      $0.edges.equalToSuperview().inset(UIEdgeInsets(top: 12, left: 14, bottom: 10, right: 14))
+    }
+  }
+}

--- a/Tooda/Sources/Scenes/CreateNote/View/CreateGuideView.swift
+++ b/Tooda/Sources/Scenes/CreateNote/View/CreateGuideView.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 import Then
+import SnapKit
 
 final class CreateGuideView: UIView {
   

--- a/Tooda/Sources/Scenes/CreateNote/View/CreateNoteGuideView.swift
+++ b/Tooda/Sources/Scenes/CreateNote/View/CreateNoteGuideView.swift
@@ -23,7 +23,7 @@ final class CreateNoteGuideView: UIView {
     static let description = TextStyle.body(color: .gray3)
   }
   
-  private enum Constants {
+  private enum Const {
     static let gradientGrayColor = UIColor(hex: "#EDF0F0")
     static let shadowColor = UIColor(hex: "#394B44")
   }
@@ -124,12 +124,12 @@ final class CreateNoteGuideView: UIView {
   
   private func applyGradientAndShadow(_ view: UIView) {
     view.do {
-      let gradient = $0.generateGradient(colors: [UIColor.white, Constants.gradientGrayColor])
+      let gradient = $0.generateGradient(colors: [UIColor.white, Const.gradientGrayColor])
       
       gradient.cornerRadius = 16
       gradient.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
       
-      gradient.makeShadow(color: Constants.shadowColor.withAlphaComponent(0.12),
+      gradient.makeShadow(color: Const.shadowColor.withAlphaComponent(0.12),
                           radius: 40,
                           opacity: 1,
                           offset: CGSize(width: 0, height: 8))

--- a/Tooda/Sources/Scenes/CreateNote/View/CreateNoteGuideView.swift
+++ b/Tooda/Sources/Scenes/CreateNote/View/CreateNoteGuideView.swift
@@ -1,5 +1,5 @@
 //
-//  CreateGuideView.swift
+//  CreateNoteGuideView.swift
 //  Tooda
 //
 //  Created by Lyine on 2021/12/12.
@@ -14,7 +14,7 @@ protocol CreateNoteGuideViewDelegate: AnyObject {
   func contentDidTapped()
 }
 
-final class CreateGuideView: UIView {
+final class CreateNoteGuideView: UIView {
   
   private(set) var didSetupConstraints = false
   


### PR DESCRIPTION
### 수정내역 (필수)
- 노트 등록 가이드 뷰를 커스텀 뷰로 만들었어요.
- 노트 등록 가이드 뷰의 탭 이벤트를 전달할 델리게이트를 선언했어요.

### 스크린샷 (선택사항)
<img src="https://user-images.githubusercontent.com/19662529/145705509-e64d556a-06bd-4f85-9236-57022adef108.png" width=320>

### Todo:
- [ ] : 노트 등록 가이드 뷰를 홈화면에 추가해요.
- [ ] : 노트 등록 가이드 뷰를 탭하면 노트 등록 화면을 새창으로 띄워줘요.
