### PR TITLE
[Domain] 홈 화면에서 노트 등록 가이드 뷰가 보이고, 탭하면 노트 등록 화면을 볼 수 있어요.

### DIFF
--- a/Tooda/Sources/Core/AppFactory.swift
+++ b/Tooda/Sources/Core/AppFactory.swift
@@ -46,7 +46,11 @@ final class AppFactory: AppFactoryType {
           authorization: self.dependency.appInject.resolve(AppAuthorizationType.self),
           createDiarySectionFactory: createDiarySectionFactory)
       )
-      return CreateNoteViewController(reactor: reactor)
+        
+      let viewController = CreateNoteViewController(reactor: reactor)
+      let navigationController = UINavigationController(rootViewController: viewController)
+      navigationController.modalPresentationStyle = .overFullScreen
+      return navigationController
 
     case .login:
       let reactor = LoginReactor(

--- a/Tooda/Sources/Scenes/Home/HomeReactor.swift
+++ b/Tooda/Sources/Scenes/Home/HomeReactor.swift
@@ -31,6 +31,7 @@ final class HomeReactor: Reactor {
     // routing
     case pushSearch
     case pushSettings
+    case presentCreateNote
   }
 
   enum Mutation {
@@ -119,6 +120,9 @@ extension HomeReactor {
       return Observable<Mutation>.empty()
     case .pushSettings:
       pushSettings()
+      return Observable<Mutation>.empty()
+    case .presentCreateNote:
+      presentCreateNote()
       return Observable<Mutation>.empty()
     }
   }
@@ -266,6 +270,15 @@ extension HomeReactor {
     self.dependency.coordinator.transition(
       to: .settings,
       using: .push,
+      animated: true,
+      completion: nil
+    )
+  }
+  
+  private func presentCreateNote() {
+    self.dependency.coordinator.transition(
+      to: .createNote,
+      using: .modal,
       animated: true,
       completion: nil
     )

--- a/Tooda/Sources/Scenes/Home/HomeViewController.swift
+++ b/Tooda/Sources/Scenes/Home/HomeViewController.swift
@@ -77,14 +77,15 @@ final class HomeViewController: BaseViewController<HomeReactor> {
     $0.contentInset = Metric.notebookContentInset
     $0.register(NotebookCell.self, forCellWithReuseIdentifier: Const.notebookCellIdentifier)
   }
-
+  
   private let noteGuideView = CreateNoteGuideView(frame: .zero)
+
 
   // MARK: Custom Action
 
   private let rxScrollToItem = BehaviorRelay<Int>(value: 0)
   private let rxPickDate = PublishRelay<Date>()
-
+  private let rxNoteGuideViewTap = PublishRelay<Void>()
 
   // MARK: Initializing
 
@@ -127,6 +128,12 @@ final class HomeViewController: BaseViewController<HomeReactor> {
     self.rxPickDate
       .asObservable()
       .map { HomeReactor.Action.pickDate($0) }
+      .bind(to: reactor.action)
+      .disposed(by: self.disposeBag)
+    
+    self.rxNoteGuideViewTap
+      .asObservable()
+      .map { HomeReactor.Action.presentCreateNote }
       .bind(to: reactor.action)
       .disposed(by: self.disposeBag)
 
@@ -196,6 +203,8 @@ final class HomeViewController: BaseViewController<HomeReactor> {
       action: #selector(didTapMonthTitle),
       for: .touchUpInside
     )
+    
+    self.noteGuideView.delegate = self
   }
 
   override func configureConstraints() {
@@ -292,5 +301,13 @@ extension HomeViewController: UICollectionViewDelegateFlowLayout {
       at: .centeredHorizontally,
       animated: true
     )
+  }
+}
+
+// MARK: - CreateNoteGuideViewDelegate
+
+extension HomeViewController: CreateNoteGuideViewDelegate {
+  func contentDidTapped() {
+    self.rxNoteGuideViewTap.accept(())
   }
 }

--- a/Tooda/Sources/Scenes/Home/HomeViewController.swift
+++ b/Tooda/Sources/Scenes/Home/HomeViewController.swift
@@ -78,6 +78,7 @@ final class HomeViewController: BaseViewController<HomeReactor> {
     $0.register(NotebookCell.self, forCellWithReuseIdentifier: Const.notebookCellIdentifier)
   }
 
+  private let noteGuideView = CreateNoteGuideView(frame: .zero)
 
   // MARK: Custom Action
 
@@ -187,6 +188,7 @@ final class HomeViewController: BaseViewController<HomeReactor> {
       $0.addSubview(self.monthTitleButton)
       $0.addSubview(self.noteCountLabel)
       $0.addSubview(self.notebookCollectionView)
+      $0.addSubview(self.noteGuideView)
     }
 
     self.monthTitleButton.addTarget(
@@ -213,6 +215,11 @@ final class HomeViewController: BaseViewController<HomeReactor> {
       $0.right.equalToSuperview()
       $0.top.equalTo(self.noteCountLabel.snp.bottom).offset(35.0)
       $0.height.equalTo(Metric.notebookCellSize.height)
+    }
+    
+    self.noteGuideView.snp.makeConstraints {
+      $0.leading.trailing.equalToSuperview()
+      $0.bottom.equalToSuperview()
     }
   }
 }

--- a/Tooda/Sources/Scenes/Home/HomeViewController.swift
+++ b/Tooda/Sources/Scenes/Home/HomeViewController.swift
@@ -227,8 +227,7 @@ final class HomeViewController: BaseViewController<HomeReactor> {
     }
     
     self.noteGuideView.snp.makeConstraints {
-      $0.leading.trailing.equalToSuperview()
-      $0.bottom.equalToSuperview()
+      $0.leading.trailing.bottom.equalToSuperview()
     }
   }
 }


### PR DESCRIPTION
### 수정내역 (필수)
- 홈화면에서 노트 등록 가이드 뷰를 정의하고 view에 추가하고 제약을 설정했어요.
- 노트 등록 가이드 뷰에 델리게이트를 연결하고, rxNoteGuideViewTap로 델리게이트 로직과 연결했어요.
- 홈 Reactor에서 노트 등록 화면을 호출하기 위한 Action과 Mutation에서 코디네이팅 로직을 구현했어요.
- AppFactory에서 CreateNoteViewController를 생성할 때 NavigationController를 감싸서 반환해줘요.

### 스크린샷 (선택사항)
![ezgif com-gif-maker (4)](https://user-images.githubusercontent.com/19662529/145998321-e92e8769-9f6f-46e4-af5f-4ec667e8fb04.gif)

