### PR TITLE
[UI] 노트 등록 화면에 링크 화면을 추가했어요, 그 외 기타 기능 추가

### DIFF
--- a/Tooda/Sources/Common/Extensions/UIImage+Asset.swift
+++ b/Tooda/Sources/Common/Extensions/UIImage+Asset.swift
@@ -37,6 +37,7 @@ enum AppImage: String {
   
   case closeButton = "cancel"
   case moreButton = "more"
+  case link = "link"
 }
 
 extension UIImage {

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
@@ -18,6 +18,10 @@ class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
   typealias Reactor = CreateNoteViewReactor
 
   typealias Section = RxTableViewSectionedReloadDataSource<NoteSection>
+  
+  private enum Metric {
+    static let linkButtonSize: CGFloat = 20.0
+  }
 
   // MARK: Custom Action
   
@@ -87,6 +91,14 @@ class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
     $0.register(NoteImageCell.self)
     $0.register(NoteStockCell.self)
   }
+  
+  private let linkContainerView = UIView().then {
+    $0.backgroundColor = .white
+  }
+  
+  private let linkButton = UIButton().then {
+    $0.setImage(UIImage(type: .link), for: .normal)
+  }
 
   // MARK: Initialize
 
@@ -119,6 +131,10 @@ class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
     [tableView].forEach {
       self.view.addSubview($0)
     }
+    
+    self.tableView.addSubview(self.linkContainerView)
+    
+    self.linkContainerView.addSubview(self.linkButton)
   }
 
   override func configureConstraints() {
@@ -129,6 +145,18 @@ class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
       $0.left.equalToSuperview().offset(14)
       $0.right.equalToSuperview().offset(-14)
       $0.bottom.equalTo(self.view.safeAreaLayoutGuide.snp.bottom)
+    }
+    
+    linkContainerView.snp.makeConstraints {
+      $0.leading.trailing.equalToSuperview()
+      $0.bottom.equalTo(self.view.keyboardLayoutGuide.snp.top)
+    }
+    
+    linkButton.snp.makeConstraints {
+      $0.top.equalToSuperview().offset(8)
+      $0.centerY.equalToSuperview()
+      $0.leading.equalToSuperview()
+      $0.size.equalTo(Metric.linkButtonSize)
     }
   }
 

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
@@ -117,6 +117,7 @@ class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
     super.viewDidLoad()
     
     configureNavigation()
+    configureTapGesture()
   }
   
   override func viewWillAppear(_ animated: Bool) {
@@ -210,6 +211,16 @@ extension CreateNoteViewController {
   func configureNavigation() {
     self.navigationItem.title = Date().description
     self.navigationItem.leftBarButtonItem = self.closeBarbutton
+  }
+  
+  private func configureTapGesture() {
+    let tapGesture = UITapGestureRecognizer(target: self, action: #selector(contentViewDidTap))
+    self.view.addGestureRecognizer(tapGesture)
+  }
+  
+  @objc
+  private func contentViewDidTap(_ sender: Any?) {
+    self.view.endEditing(true)
   }
 }
 

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
@@ -92,6 +92,17 @@ class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
     $0.register(NoteStockCell.self)
   }
   
+  private let linkStackView = UIStackView().then {
+    $0.axis = .vertical
+    $0.alignment = .fill
+    $0.spacing = 8.0
+    $0.translatesAutoresizingMaskIntoConstraints = false
+  }
+  
+  private let lineView = UIView().then {
+    $0.backgroundColor = .gray5
+  }
+  
   private let linkContainerView = UIView().then {
     $0.backgroundColor = .white
   }
@@ -129,11 +140,13 @@ class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
 
     self.view.backgroundColor = .white
 
-    [tableView].forEach {
+    [tableView, linkStackView].forEach {
       self.view.addSubview($0)
     }
     
-    self.tableView.addSubview(self.linkContainerView)
+    [lineView, linkContainerView].forEach {
+      self.linkStackView.addArrangedSubview($0)
+    }
     
     self.linkContainerView.addSubview(self.linkButton)
   }
@@ -148,15 +161,19 @@ class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
       $0.bottom.equalTo(self.view.safeAreaLayoutGuide.snp.bottom)
     }
     
-    linkContainerView.snp.makeConstraints {
+    linkStackView.snp.makeConstraints {
       $0.leading.trailing.equalToSuperview()
       $0.bottom.equalTo(self.view.keyboardLayoutGuide.snp.top)
+    }
+    
+    lineView.snp.makeConstraints {
+      $0.height.equalTo(1)
     }
     
     linkButton.snp.makeConstraints {
       $0.top.equalToSuperview().offset(8)
       $0.centerY.equalToSuperview()
-      $0.leading.equalToSuperview()
+      $0.leading.equalToSuperview().offset(14)
       $0.size.equalTo(Metric.linkButtonSize)
     }
   }

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
@@ -96,7 +96,6 @@ class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
     $0.axis = .vertical
     $0.alignment = .fill
     $0.spacing = 8.0
-    $0.translatesAutoresizingMaskIntoConstraints = false
   }
   
   private let lineView = UIView().then {


### PR DESCRIPTION
### 수정내역 (필수)
- UIImage Extension에 link case 추가했어요.
- 노트 등록 화면에 링크 화면을 추가했어요.
- 노트 등록 화면에서 텍스트 필드가 아닌 뷰 영역을 탭하면 키보드가 내려갈 수 있게 제스처 메소드를 추가했어요.

### 스크린샷 (선택사항)
![ezgif com-gif-maker (6)](https://user-images.githubusercontent.com/19662529/146671927-7ca82ad6-f0cf-49e5-818f-7c8acad3004e.gif)
