### PR TITLE
[UI] 노트 링크 셀의 UI를 구현했어요.

### DIFF
--- a/Tooda/Sources/Scenes/CreateNote/Cells/NoteLinkCell.swift
+++ b/Tooda/Sources/Scenes/CreateNote/Cells/NoteLinkCell.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 
+import Then
 import ReactorKit
 import SnapKit
 
@@ -16,11 +17,116 @@ class NoteLinkCell: BaseTableViewCell, View {
 
   var disposeBag: DisposeBag = DisposeBag()
   
+  private enum Const {
+    static let labelLineNumbers = 1
+  }
+  
+  private enum Font {
+    static let title = TextStyle.bodyBold(color: .gray1)
+    static let caption = TextStyle.caption(color: .gray3)
+  }
+  
+  private enum Metric {
+    static let imageViewHeight: CGFloat = 94.0
+    static let linkIconSize: CGSize = CGSize(width: 14.0, height: 14.0)
+  }
+  
+  // MARK: UI Properties
+  
+  private let containerStackView = UIStackView().then {
+    $0.axis = .horizontal
+    $0.alignment = .fill
+    $0.layer.cornerRadius = 8.0
+    $0.clipsToBounds = true
+    $0.layer.borderColor = UIColor.gray4.cgColor
+    $0.layer.borderWidth = 1.0
+    $0.translatesAutoresizingMaskIntoConstraints = false
+  }
+  
+  private let imageContentView = UIImageView().then {
+    $0.contentMode = .scaleAspectFill
+  }
+  
+  private let linkInfoStackView = UIStackView().then {
+    $0.axis = .vertical
+    $0.distribution = .fill
+    $0.layoutMargins = UIEdgeInsets(top: 8.5, left: 16, bottom: 7.5, right: 15)
+    $0.isLayoutMarginsRelativeArrangement = true
+    $0.translatesAutoresizingMaskIntoConstraints = false
+  }
+  
+  private let linkContainerView = UIStackView().then {
+    $0.axis = .horizontal
+    $0.alignment = .center
+    $0.spacing = 3.94
+    $0.translatesAutoresizingMaskIntoConstraints = false
+  }
+
+  private let linkIconView = UIImageView().then {
+    $0.contentMode = .scaleAspectFit
+  }
+  
+  private let linkTitleLabel = UILabel().then {
+    $0.numberOfLines = Const.labelLineNumbers
+  }
+  
+  private let descriptionCaptionLabel = UILabel().then {
+    $0.numberOfLines = Const.labelLineNumbers
+  }
+  
+  private let linkCaptionLabel = UILabel().then {
+    $0.numberOfLines = Const.labelLineNumbers
+  }
+  
   // MARK: Cell Life Cycle
+  
+  func configure(reactor: Reactor) {
+    super.configure()
+    self.reactor = reactor
+  }
   
   override func prepareForReuse() {
     super.prepareForReuse()
     disposeBag = DisposeBag()
+  }
+  
+  override func configureUI() {
+    super.configureUI()
+    
+    self.addSubview(containerStackView)
+    
+    [imageContentView, linkInfoStackView].forEach {
+      self.containerStackView.addArrangedSubview($0)
+    }
+    
+    [linkContainerView, descriptionCaptionLabel, linkCaptionLabel].forEach {
+      self.linkInfoStackView.addArrangedSubview($0)
+    }
+    
+    [linkIconView, linkTitleLabel].forEach {
+      self.linkContainerView.addArrangedSubview($0)
+    }
+  }
+  
+  override func setupConstraints() {
+    super.setupConstraints()
+    
+    containerStackView.snp.makeConstraints {
+      $0.top.equalToSuperview().offset(10)
+      $0.leading.trailing.equalToSuperview()
+      $0.height.equalTo(Metric.imageViewHeight)
+    }
+    
+    imageContentView.snp.makeConstraints {
+      $0.width.equalTo(Metric.imageViewHeight)
+    }
+    
+    linkIconView.snp.makeConstraints {
+      $0.size.equalTo(Metric.linkIconSize)
+    }
+    
+    imageContentView.setContentHuggingPriority(.required, for: .horizontal)
+    imageContentView.setContentHuggingPriority(.required, for: .vertical)
   }
 
   func bind(reactor: Reactor) {

--- a/Tooda/Sources/Scenes/CreateNote/Cells/NoteLinkCell.swift
+++ b/Tooda/Sources/Scenes/CreateNote/Cells/NoteLinkCell.swift
@@ -40,7 +40,6 @@ class NoteLinkCell: BaseTableViewCell, View {
     $0.clipsToBounds = true
     $0.layer.borderColor = UIColor.gray4.cgColor
     $0.layer.borderWidth = 1.0
-    $0.translatesAutoresizingMaskIntoConstraints = false
   }
   
   private let imageContentView = UIImageView().then {
@@ -52,14 +51,12 @@ class NoteLinkCell: BaseTableViewCell, View {
     $0.distribution = .fill
     $0.layoutMargins = UIEdgeInsets(top: 8.5, left: 16, bottom: 7.5, right: 15)
     $0.isLayoutMarginsRelativeArrangement = true
-    $0.translatesAutoresizingMaskIntoConstraints = false
   }
   
   private let linkContainerView = UIStackView().then {
     $0.axis = .horizontal
     $0.alignment = .center
     $0.spacing = 3.94
-    $0.translatesAutoresizingMaskIntoConstraints = false
   }
 
   private let linkIconView = UIImageView().then {
@@ -124,9 +121,6 @@ class NoteLinkCell: BaseTableViewCell, View {
     linkIconView.snp.makeConstraints {
       $0.size.equalTo(Metric.linkIconSize)
     }
-    
-    imageContentView.setContentHuggingPriority(.required, for: .horizontal)
-    imageContentView.setContentHuggingPriority(.required, for: .vertical)
   }
 
   func bind(reactor: Reactor) {

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
@@ -88,6 +88,7 @@ class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
     $0.register(EmptyNoteStockCell.self)
     $0.register(NoteImageCell.self)
     $0.register(NoteStockCell.self)
+    $0.register(NoteLinkCell.self)
   }
 
   // MARK: Initialize

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
@@ -59,8 +59,10 @@ class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
         let cell = tableView.dequeue(NoteStockCell.self, indexPath: indexPath)
         cell.configure(with: reactor)
         return cell
-    default:
-      return UITableViewCell()
+    case .link(let reactor):
+        let cell = tableView.dequeue(NoteLinkCell.self, indexPath: indexPath)
+        cell.configure(reactor: reactor)
+        return cell
     }
   }, canEditRowAtIndexPath: { _, _ in true })
 


### PR DESCRIPTION
### 수정내역 (필수)
- NoteLinkCell의 UI 프로퍼티를 정의하고 제약조건을 정의했어요.
- 노트등록 화면의 DataSource 클로저에서 Link SectionItem Case를 구현했어요.
- 노트등록 화면에서 NoteLinkCell을 등록했어요.

### 스크린샷 (선택사항)
<img src="https://user-images.githubusercontent.com/19662529/146674316-c0e34d98-e713-422c-bf35-d81e1f8847b4.png" width = 320>

### Todo:
- [ ] : Description 영역의 title label 아이콘을 추가해요.
- [ ] : cell.configure의 파라미터 타입을 Reactor가 아닌 내부 ViewModel Struct를 사용할거에요.
- [ ] : LinkCellReactor를 제거하고 관련된 SectionItem도 변경할 예정이에요.
