### PR TITLE
[Core] LinkPreview 라이브러리와 구현체를 추가했어요.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -16,6 +16,7 @@ target 'Tooda' do
 	pod 'SwiftLint'
   pod 'Firebase/Crashlytics'
   pod 'Firebase/Analytics'
+  pod 'SwiftLinkPreview', '~> 3.4.0'
 	pod 'netfox', configuration: %w(Debug)
 
   # Pods for TodaTest

--- a/Tooda/Sources/Core/AppInject.swift
+++ b/Tooda/Sources/Core/AppInject.swift
@@ -80,6 +80,10 @@ final class AppInject: AppInjectRegister, AppInjectResolve {
         ]
       )
     }
+    
+    container.register(LinkPreViewServiceType.self) { _ in
+      LinkPreviewService()
+    }.inObjectScope(.container)
   }
   
   func resolve<Object>(_ serviceType: Object.Type) -> Object {

--- a/Tooda/Sources/Utils/LinkPreviewService.swift
+++ b/Tooda/Sources/Utils/LinkPreviewService.swift
@@ -7,8 +7,22 @@
 
 import SwiftLinkPreview
 
+struct LinkPreviewResponse {
+  var title: String?
+  var imageURL: String?
+  var canonicalUrl: String?
+  var description: String?
+  
+  init(response: Response) {
+    self.title = response.title
+    self.imageURL = response.image
+    self.canonicalUrl = response.canonicalUrl
+    self.description = response.description
+  }
+}
+
 protocol LinkPreViewServiceType {
-  func fetchMetaData(urlString: String, completion: @escaping (Response?) -> Void)
+  func fetchMetaData(urlString: String, completion: @escaping (LinkPreviewResponse?) -> Void)
 }
 
 final class LinkPreviewService: LinkPreViewServiceType {
@@ -18,12 +32,12 @@ final class LinkPreviewService: LinkPreViewServiceType {
     responseQueue: DispatchQueue.main,
     cache: InMemoryCache())
   
-  func fetchMetaData(urlString: String, completion: @escaping (Response?) -> Void) {
+  func fetchMetaData(urlString: String, completion: @escaping (LinkPreviewResponse?) -> Void) {
     if let cache = self.preview.cache.slp_getCachedResponse(url: urlString) {
-      completion(cache)
+      completion(.init(response: cache))
     } else {
       self.preview.preview(urlString, onSuccess: {
-        completion($0)
+        completion(.init(response: $0))
       }, onError: { _ in
         completion(nil)
       })

--- a/Tooda/Sources/Utils/LinkPreviewService.swift
+++ b/Tooda/Sources/Utils/LinkPreviewService.swift
@@ -1,0 +1,32 @@
+//
+//  LinkPreviewService.swift
+//  Tooda
+//
+//  Created by Lyine on 2021/12/26.
+//
+
+import SwiftLinkPreview
+
+protocol LinkPreViewServiceType {
+  func fetchMetaData(urlString: String, completion: @escaping (Response?) -> Void)
+}
+
+final class LinkPreviewService: LinkPreViewServiceType {
+  let preview = SwiftLinkPreview(
+    session: URLSession.shared,
+    workQueue: SwiftLinkPreview.defaultWorkQueue,
+    responseQueue: DispatchQueue.main,
+    cache: InMemoryCache())
+  
+  func fetchMetaData(urlString: String, completion: @escaping (Response?) -> Void) {
+    if let cache = self.preview.cache.slp_getCachedResponse(url: urlString) {
+      completion(cache)
+    } else {
+      self.preview.preview(urlString, onSuccess: {
+        completion($0)
+      }, onError: { _ in
+        completion(nil)
+      })
+    }
+  }
+}


### PR DESCRIPTION
### 수정내역 (필수)
- URL을 바탕으로 Rich링크를 생성해 줄 수 있는 써드파티 라이브러리를 PodFile에 추가했어요. [참고](https://github.com/LeonardoCardoso/SwiftLinkPreview)
- 리치 링크의 생성을 담당할 서비스에 대한 `LinkPreviewSerivceType`프로토콜을 정의하고 프로토콜을 채택한 `LinkPreviewSerivce` 클래스를 정의했어요.
- Dependency를 사용하는 쪽에서 SwiftLinkPreview에 대한 모듈 의존성을 모르게하기 위해 `LinkPreviewResponse` 구조체를 설계하고 escaping 전달인자로 사용해요.
- AppInject DI Container에서 LinkPreviewSerivceType을 등록했어요.
