### PR TITLE
[Domain] 노트 등록 화면에서 링크 아이템을 볼 수 있어요. 그 외 기타 변경건 1건

### DIFF
--- a/Tooda/Sources/Core/AppFactory.swift
+++ b/Tooda/Sources/Core/AppFactory.swift
@@ -44,6 +44,8 @@ final class AppFactory: AppFactoryType {
           service: self.dependency.appInject.resolve(NetworkingProtocol.self),
           coordinator: self.dependency.appInject.resolve(AppCoordinatorType.self),
           authorization: self.dependency.appInject.resolve(AppAuthorizationType.self),
+          linkPreviewService:
+            self.dependency.appInject.resolve(LinkPreViewServiceType.self),
           createDiarySectionFactory: createDiarySectionFactory)
       )
         

--- a/Tooda/Sources/Scenes/CreateNote/Cells/NoteImageCell.swift
+++ b/Tooda/Sources/Scenes/CreateNote/Cells/NoteImageCell.swift
@@ -17,7 +17,7 @@ class NoteImageCell: BaseTableViewCell, View {
   typealias Section = RxCollectionViewSectionedReloadDataSource<NoteImageSection>
   
   private enum Constants {
-    static let baseItemValue: CGFloat = 94
+    static let baseItemValue: CGFloat = 74
   }
 
   var disposeBag: DisposeBag = DisposeBag()

--- a/Tooda/Sources/Scenes/CreateNote/Cells/NoteLinkCell.swift
+++ b/Tooda/Sources/Scenes/CreateNote/Cells/NoteLinkCell.swift
@@ -27,51 +27,63 @@ class NoteLinkCell: BaseTableViewCell, View {
   }
   
   private enum Metric {
-    static let imageViewHeight: CGFloat = 94.0
+    static let imageViewSize: CGSize = CGSize(width: 74.0, height: 74.0)
     static let linkIconSize: CGSize = CGSize(width: 14.0, height: 14.0)
+    static let lineViewWidth: CGFloat = 1.0
   }
   
   // MARK: UI Properties
   
+  private let indcatorView = UIActivityIndicatorView()
+  
   private let containerStackView = UIStackView().then {
     $0.axis = .horizontal
-    $0.alignment = .fill
     $0.layer.cornerRadius = 8.0
-    $0.clipsToBounds = true
     $0.layer.borderColor = UIColor.gray4.cgColor
     $0.layer.borderWidth = 1.0
+    $0.clipsToBounds = true
+    $0.translatesAutoresizingMaskIntoConstraints = false
   }
   
-  private let imageContentView = UIImageView().then {
+  private let thumnailView = UIImageView().then {
     $0.contentMode = .scaleAspectFill
+    $0.clipsToBounds = true
   }
   
-  private let linkInfoStackView = UIStackView().then {
+  private let lineView = UIView().then {
+    $0.backgroundColor = UIColor.gray4
+  }
+  
+  private let infoStackView = UIStackView().then {
     $0.axis = .vertical
-    $0.distribution = .fill
+    $0.distribution = .equalCentering
+    $0.alignment = .leading
     $0.layoutMargins = UIEdgeInsets(top: 8.5, left: 16, bottom: 7.5, right: 15)
     $0.isLayoutMarginsRelativeArrangement = true
+    $0.translatesAutoresizingMaskIntoConstraints = false
   }
   
-  private let linkContainerView = UIStackView().then {
+  private let titleStackView = UIStackView().then {
     $0.axis = .horizontal
     $0.alignment = .center
+    $0.distribution = .fill
     $0.spacing = 3.94
   }
 
-  private let linkIconView = UIImageView().then {
+  private let linkIconView = UIImageView(image: UIImage(type: .link)).then {
     $0.contentMode = .scaleAspectFit
   }
   
-  private let linkTitleLabel = UILabel().then {
+  private let titleLabel = MarginLabel(edgeInsets: UIEdgeInsets(top: 0, left: 0, bottom: 5, right: 0)).then {
+    $0.numberOfLines = Const.labelLineNumbers
+    $0.verticalAlignment = .top
+  }
+  
+  private let descriptionLabel = UILabel().then {
     $0.numberOfLines = Const.labelLineNumbers
   }
   
-  private let descriptionCaptionLabel = UILabel().then {
-    $0.numberOfLines = Const.labelLineNumbers
-  }
-  
-  private let linkCaptionLabel = UILabel().then {
+  private let canonicalLabel = UILabel().then {
     $0.numberOfLines = Const.labelLineNumbers
   }
   
@@ -90,34 +102,41 @@ class NoteLinkCell: BaseTableViewCell, View {
   override func configureUI() {
     super.configureUI()
     
-    self.addSubview(containerStackView)
+    self.contentView.addSubviews(containerStackView, indcatorView)
     
-    [imageContentView, linkInfoStackView].forEach {
+    [thumnailView, lineView, infoStackView].forEach {
       self.containerStackView.addArrangedSubview($0)
     }
     
-    [linkContainerView, descriptionCaptionLabel, linkCaptionLabel].forEach {
-      self.linkInfoStackView.addArrangedSubview($0)
+    [titleStackView, descriptionLabel, canonicalLabel].forEach {
+      self.infoStackView.addArrangedSubview($0)
     }
-    
-    [linkIconView, linkTitleLabel].forEach {
-      self.linkContainerView.addArrangedSubview($0)
+
+    [linkIconView, titleLabel].forEach {
+      self.titleStackView.addArrangedSubview($0)
     }
   }
   
   override func setupConstraints() {
     super.setupConstraints()
     
+    indcatorView.snp.makeConstraints {
+      $0.center.equalToSuperview()
+    }
+    
     containerStackView.snp.makeConstraints {
       $0.top.equalToSuperview().offset(10)
-      $0.leading.trailing.equalToSuperview()
-      $0.height.equalTo(Metric.imageViewHeight)
+      $0.leading.trailing.bottom.equalToSuperview()
     }
     
-    imageContentView.snp.makeConstraints {
-      $0.width.equalTo(Metric.imageViewHeight)
+    thumnailView.snp.makeConstraints {
+      $0.size.equalTo(Metric.imageViewSize)
     }
     
+    lineView.snp.makeConstraints {
+      $0.width.equalTo(Metric.lineViewWidth)
+    }
+        
     linkIconView.snp.makeConstraints {
       $0.size.equalTo(Metric.linkIconSize)
     }

--- a/Tooda/Sources/Scenes/CreateNote/Cells/Reactors/NoteLinkCellReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/Cells/Reactors/NoteLinkCellReactor.swift
@@ -9,30 +9,86 @@
 import ReactorKit
 
 final class NoteLinkCellReactor: Reactor {
+  
+  enum LinkFetchError: Error {
+    case dataNotFetched
+  }
+  
   enum Action {
-
+    case fetchLink
   }
 
   enum Mutation {
-
+    case fetchLink(LinkPreviewResponse)
+    case isLoading(Bool)
   }
 
   struct State {
-
+    var isLoading: Bool = true
+    var hasNotTitle: Bool = true
+    var response: LinkPreviewResponse?
+  }
+  
+  struct Dependency {
+    var service: LinkPreViewServiceType
   }
 
   let initialState: State
+  private let dependency: Dependency
+  private let payload: String
 
-  init() {
+  init(
+    dependency: Dependency,
+    payload: String
+  ) {
     initialState = State()
+    self.dependency = dependency
+    self.payload = payload
   }
 
   func mutate(action: Action) -> Observable<Mutation> {
-    return .empty()
+    switch action {
+      case .fetchLink:
+        return .concat([.just(.isLoading(true)), self.fetchMetaData(), .just(.isLoading(false))])
+    }
   }
 
-  func reduce(state: State, mutation: Action) -> State {
+  func reduce(state: State, mutation: Mutation) -> State {
     var newState = state
+    
+    switch mutation {
+      case .fetchLink(let response):
+        newState.response = response
+        newState.hasNotTitle = (response.title == nil)
+      case .isLoading(let isLoading):
+        newState.isLoading = isLoading
+    }
+    
     return newState
+  }
+}
+
+// MARK: - Extensions
+
+// MARK: - Mutation
+
+extension NoteLinkCellReactor {
+  private func fetchMetaData() -> Observable<Mutation> {
+    let linkURLString = self.payload
+    
+    return Observable.create { [weak self] observer in
+      self?.dependency.service.fetchMetaData(urlString: linkURLString, completion: { response in
+        
+        if let response = response {
+          observer.onNext(Mutation.fetchLink(response))
+        } else {
+          observer.onError(LinkFetchError.dataNotFetched)
+        }
+
+        observer.onCompleted()
+      })
+      
+      return Disposables.create()
+    }
   }
 }

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
@@ -19,6 +19,10 @@ class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
 
   typealias Section = RxTableViewSectionedReloadDataSource<NoteSection>
   
+  private enum Const {
+    static let linkItemMaxCount: Int = 2
+  }
+  
   private enum Metric {
     static let linkButtonSize: CGFloat = 20.0
   }
@@ -29,6 +33,8 @@ class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
   let imagePickerDataSelectedRelay: PublishRelay<Data> = PublishRelay()
   
   let rxAddStockDidTapRelay: PublishRelay<Void> = PublishRelay()
+  
+  private let rxLinkURLDidAddedRelay: PublishRelay<String> = PublishRelay()
   
   // MARK: Properties
   lazy var dataSource: Section = Section(configureCell: { _, tableView, indexPath, item -> UITableViewCell in
@@ -206,6 +212,12 @@ class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
     
     rxAddStockDidTapRelay
       .map { Reactor.Action.showAddStockView }
+      .bind(to: reactor.action)
+      .disposed(by: self.disposeBag)
+    
+    rxLinkURLDidAddedRelay
+      .take(Const.linkItemMaxCount)
+      .map { Reactor.Action.linkURLDidAdded($0) }
       .bind(to: reactor.action)
       .disposed(by: self.disposeBag)
     

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -37,6 +37,7 @@ final class CreateNoteViewReactor: Reactor {
     case uploadImage(Data)
     case showAddStockView
     case stockItemDidAdded(NoteStock)
+    case linkURLDidAdded(String)
   }
 
   enum Mutation {
@@ -44,6 +45,7 @@ final class CreateNoteViewReactor: Reactor {
     case present(ViewPresentType)
     case fetchImageSection(NoteSectionItem)
     case fetchStockSection(NoteSectionItem)
+    case fetchLinkSection(NoteSectionItem)
   }
 
   struct State: Then {
@@ -77,6 +79,8 @@ final class CreateNoteViewReactor: Reactor {
       return presentAddStockView()
     case .stockItemDidAdded(let stock):
       return self.makeStockSectionItem(stock)
+    case .linkURLDidAdded(let url):
+      return self.makeLinkSectionItem(url)
     case .dismissView:
         return dismissView()
     default:
@@ -100,6 +104,8 @@ final class CreateNoteViewReactor: Reactor {
       newState.sections[NoteSection.Identity.image.rawValue].items = [sectionItem]
     case .fetchStockSection(let sectionItem):
       newState.sections[NoteSection.Identity.stock.rawValue].items.append(sectionItem)
+    case .fetchLinkSection(let sectionItem):
+      newState.sections[NoteSection.Identity.link.rawValue].items.append(sectionItem)
     }
 
     return newState
@@ -206,6 +212,17 @@ extension CreateNoteViewReactor {
     let sectionItem = NoteSectionItem.stock(reator)
     
     return .just(.fetchStockSection(sectionItem))
+  }
+  
+  private func makeLinkSectionItem(_ url: String) -> Observable<Mutation> {
+    let linkReactor = NoteLinkCellReactor(dependency: .init(
+      service: self.dependency.linkPreviewService),
+                                          payload: url
+    )
+    
+    let linkSectionItem: NoteSectionItem = NoteSectionItem.link(linkReactor)
+    
+    return .just(.fetchLinkSection(linkSectionItem))
   }
 }
 

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -25,6 +25,7 @@ final class CreateNoteViewReactor: Reactor {
     let service: NetworkingProtocol
     let coordinator: AppCoordinatorType
     let authorization: AppAuthorizationType
+    let linkPreviewService: LinkPreViewServiceType
     let createDiarySectionFactory: CreateNoteSectionType
   }
 


### PR DESCRIPTION
### 수정내역 (필수)
- 노트 등록 Reactor의 Dependency에 `LinkPreviewSerivce` 의존성을 추가했어요.
- 노트 등록 Reactor에서 Action에 전달받은 LinkURL로 LinkSectionItem을 그려주기 위한 Mutation, State 로직을 구현했어요.
-`NoteLinkCellReactor` 의 Dependency에 `LinkPreviewSerivce` 의존성을 추가했어요.
- `NoteLinkCellReactor`의 State에 linkResponse와 기타 UI를 변경하기 위한 State를 정의했어요.
- `NoteLinkCell`의 세부 UI를 구현하고 일부 프로퍼티의 이름을 컨텐츠에 맞게 변경했어요.
- NoteLinkCell에서 일부 StackView에 `translatesAutoresizingMaskIntoConstraints = false ` 속성이 미리 정해진건 Cell이 Configure 되는 시점에 UI가 깨지는 문제가 발생해서 이를 해결하기 위해 추가했어요.
- NoteLinkCell에 `LoadingIndicator` 를 추가했어요.
-  `NoteLinkCell` 의 Reactor Binding 코드를 추가했어요.
- `NoteImageCell`의 Size를 Figma 디자인대로 변경했어요.

### 스크린샷 (선택사항)
![ezgif com-gif-maker (7)](https://user-images.githubusercontent.com/19662529/147830178-ead719a6-d4b3-4dfb-ac31-c391fb1ff8d9.gif)

