### PR TITLE
[Util] Info.plist에서 App Build Number가 누락된 부분을 수정했어요.

### DIFF
--- a/Tooda/Sources/SupportFiles/Info.plist
+++ b/Tooda/Sources/SupportFiles/Info.plist
@@ -20,6 +20,8 @@
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleVersion</key>
 	<string>$(APP_VERSION)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(APP_BUILD)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSPhotoLibraryAddUsageDescription</key>


### PR DESCRIPTION
### 수정내역 (필수)
- Info.plist에서 App Build Number가 누락되어 앱을 실행할 수 없는 문제를 수정했어요.
