### PR TITLE
[Domain] 노트 등록 화면의 UI를 수정했어요.

### DIFF
--- a/Tooda/Sources/Scenes/CreateNote/Cells/EmptyNoteStockCell.swift
+++ b/Tooda/Sources/Scenes/CreateNote/Cells/EmptyNoteStockCell.swift
@@ -25,7 +25,6 @@ class EmptyNoteStockCell: BaseTableViewCell, View {
   let containerView = UIView().then {
     $0.layer.borderColor = Constants.baseColor?.cgColor
     $0.layer.borderWidth = 1.0
-    $0.layer.cornerRadius = 8.0
     $0.layer.masksToBounds = true
   }
   

--- a/Tooda/Sources/Scenes/CreateNote/Cells/NoteContentCell.swift
+++ b/Tooda/Sources/Scenes/CreateNote/Cells/NoteContentCell.swift
@@ -17,7 +17,7 @@ class NoteContentCell: BaseTableViewCell, View {
 
   var disposeBag: DisposeBag = DisposeBag()
   
-  private enum Constants {
+  private enum Const {
     static let baseColor: UIColor = UIColor.gray3
     
     static let baseTextColor: UIColor = UIColor.gray1
@@ -32,23 +32,23 @@ class NoteContentCell: BaseTableViewCell, View {
   let titleTextField = BolderTextField(frame: .zero).then {
     $0.font = UIFont.systemFont(ofSize: 13, weight: .bold)
     $0.textColor = UIColor(type: .gray3)
-    $0.attributedPlaceholder = Constants.titlePlaceHolderStyledText
-    $0.layer.borderColor = Constants.baseColor.cgColor
+    $0.attributedPlaceholder = Const.titlePlaceHolderStyledText
+    $0.layer.borderColor = Const.baseColor.cgColor
     $0.layer.cornerRadius = 8.0
   }
 
   let contentTextFieldBackgroundView = UIView().then {
     $0.clipsToBounds = true
     $0.layer.cornerRadius = 8.0
-    $0.layer.borderColor = Constants.baseColor.cgColor
+    $0.layer.borderColor = Const.baseColor.cgColor
     $0.layer.borderWidth = 1.0
   }
 
   let contentTextField = UITextField().then {
     $0.font = UIFont.systemFont(ofSize: 13, weight: .regular)
-    $0.textColor = Constants.baseColor
+    $0.textColor = Const.baseColor
     $0.contentVerticalAlignment = .top
-    $0.attributedPlaceholder = Constants.contentPlaceHolderStyledText
+    $0.attributedPlaceholder = Const.contentPlaceHolderStyledText
   }
 
   func configure(reactor: Reactor) {

--- a/Tooda/Sources/Scenes/CreateNote/Cells/NoteContentCell.swift
+++ b/Tooda/Sources/Scenes/CreateNote/Cells/NoteContentCell.swift
@@ -30,15 +30,19 @@ class NoteContentCell: BaseTableViewCell, View {
     static let contentPlaceHolderStyledText = "오늘 알게된 투자 정보, 매매 기록 등을 입력해보세요.\n(최대 \(maximumContnetTextLenght)자)".styled(with: TextStyle.body(color: baseColor))
   }
 
-  let titleTextField = BolderTextField(frame: .zero).then {
-    $0.font = UIFont.systemFont(ofSize: 13, weight: .bold)
-    $0.textColor = UIColor(type: .gray3)
-    $0.attributedPlaceholder = Const.titlePlaceHolderStyledText
-    $0.layer.borderColor = Const.baseColor.cgColor
+  private let titleTextFieldBackgroundView = UIView().then {
     $0.layer.cornerRadius = 8.0
+    $0.layer.borderColor = UIColor.gray4.cgColor
+    $0.layer.borderWidth = 1.0
+  }
+  
+  let titleTextField = UITextField().then {
+    $0.font = UIFont.systemFont(ofSize: 13, weight: .bold)
+    $0.textColor = Const.baseTextColor
+    $0.attributedPlaceholder = Const.titlePlaceHolderStyledText
   }
 
-  let contentTextFieldBackgroundView = UIView().then {
+  let contentTextViewBackGroundView = UIView().then {
     $0.clipsToBounds = true
     $0.layer.cornerRadius = 8.0
     $0.layer.borderColor = Const.baseColor.cgColor
@@ -67,34 +71,39 @@ class NoteContentCell: BaseTableViewCell, View {
   override func configureUI() {
     super.configureUI()
 
-    [titleTextField, contentTextFieldBackgroundView].forEach {
+    [titleTextFieldBackgroundView, contentTextViewBackGroundView].forEach {
       self.contentView.addSubview($0)
     }
-
+    
+    [titleTextField].forEach {
+      self.titleTextFieldBackgroundView.addSubview($0)
+    }
+    
     [contentTextView].forEach {
-      self.contentTextFieldBackgroundView.addSubview($0)
+      self.contentTextViewBackGroundView.addSubview($0)
     }
   }
 
   override func setupConstraints() {
     super.setupConstraints()
 
-    titleTextField.snp.makeConstraints {
+    titleTextFieldBackgroundView.snp.makeConstraints {
       $0.top.left.right.width.equalToSuperview()
       $0.height.equalTo(43)
     }
-
-    contentTextFieldBackgroundView.snp.makeConstraints {
-      $0.top.equalTo(titleTextField.snp.bottom).offset(10)
+    
+    titleTextField.snp.makeConstraints {
+      $0.edges.equalToSuperview().inset(UIEdgeInsets(top: 12, left: 14, bottom: 10, right: 14))
+    }
+    
+    contentTextViewBackGroundView.snp.makeConstraints {
+      $0.top.equalTo(titleTextFieldBackgroundView.snp.bottom).offset(10)
       $0.left.right.bottom.width.equalToSuperview()
       $0.height.equalTo(169)
     }
-
+    
     contentTextView.snp.makeConstraints {
-      $0.top.equalToSuperview().offset(16)
-      $0.left.equalToSuperview().offset(14)
-      $0.right.equalToSuperview().offset(-14)
-      $0.bottom.equalToSuperview().offset(-16)
+      $0.edges.equalToSuperview().inset(UIEdgeInsets(top: 12, left: 9, bottom: 10, right: 9))
     }
   }
 

--- a/Tooda/Sources/Scenes/CreateNote/Cells/NoteContentCell.swift
+++ b/Tooda/Sources/Scenes/CreateNote/Cells/NoteContentCell.swift
@@ -42,10 +42,9 @@ class NoteContentCell: BaseTableViewCell, View {
     $0.attributedPlaceholder = Const.titlePlaceHolderStyledText
   }
 
-  let contentTextViewBackGroundView = UIView().then {
-    $0.clipsToBounds = true
+  private let contentTextViewBackGroundView = UIView().then {
     $0.layer.cornerRadius = 8.0
-    $0.layer.borderColor = Const.baseColor.cgColor
+    $0.layer.borderColor = UIColor.gray4.cgColor
     $0.layer.borderWidth = 1.0
   }
 

--- a/Tooda/Sources/Scenes/CreateNote/Cells/NoteContentCell.swift
+++ b/Tooda/Sources/Scenes/CreateNote/Cells/NoteContentCell.swift
@@ -58,6 +58,9 @@ class NoteContentCell: BaseTableViewCell, View {
   func configure(reactor: Reactor) {
     super.configure()
     self.reactor = reactor
+    
+    self.titleTextField.delegate = self
+    self.contentTextView.delegate = self
   }
   
   // MARK: Cell Life Cycle
@@ -108,5 +111,21 @@ class NoteContentCell: BaseTableViewCell, View {
 
   func bind(reactor: Reactor) {
 
+  }
+}
+
+// MARK: - Extensions
+
+extension NoteContentCell: UITextFieldDelegate {
+  func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+    return TextInputLimiter(maxLength: Const.maximumTitleTextLength)
+      .shouldTextInMaxLength(propertyValue: textField.text, range: range, replace: string)
+  }
+}
+
+extension NoteContentCell: UITextViewDelegate {
+  func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
+    return TextInputLimiter(maxLength: Const.maximumContnetTextLenght)
+      .shouldTextInMaxLength(propertyValue: textView.text, range: range, replace: text)
   }
 }

--- a/Tooda/Sources/Scenes/CreateNote/Cells/NoteContentCell.swift
+++ b/Tooda/Sources/Scenes/CreateNote/Cells/NoteContentCell.swift
@@ -18,24 +18,29 @@ class NoteContentCell: BaseTableViewCell, View {
   var disposeBag: DisposeBag = DisposeBag()
   
   private enum Constants {
-    static let baseColor: UIColor? = UIColor(type: .gray3)
-    static let titlePlaceHolderText: String = "제목을 입력해 주세요"
-    static let contentPlaceHolderText: String = "오늘 알게된 투자 정보, 매매 기록 등을 입력해보세요."
+    static let baseColor: UIColor = UIColor.gray3
+    
+    static let baseTextColor: UIColor = UIColor.gray1
+    
+    static let maximumTitleTextLength: Int = 35
+    static let maximumContnetTextLenght: Int = 2000
+    
+    static let titlePlaceHolderStyledText = "제목을 입력해 주세요. (최대 \(maximumTitleTextLength) 자)".styled(with: TextStyle.body(color: baseColor))
+    static let contentPlaceHolderStyledText = "오늘 알게된 투자 정보, 매매 기록 등을 입력해보세요.\n(최대 \(maximumContnetTextLenght)자)".styled(with: TextStyle.body(color: baseColor))
   }
 
   let titleTextField = BolderTextField(frame: .zero).then {
     $0.font = UIFont.systemFont(ofSize: 13, weight: .bold)
     $0.textColor = UIColor(type: .gray3)
-    $0.placeholder = Constants.titlePlaceHolderText
-    $0.placeholderColor = UIColor(type: .gray2) ?? UIColor(hex: "#D1D2D1")
-    $0.layer.borderColor = Constants.baseColor?.cgColor
+    $0.attributedPlaceholder = Constants.titlePlaceHolderStyledText
+    $0.layer.borderColor = Constants.baseColor.cgColor
     $0.layer.cornerRadius = 8.0
   }
 
   let contentTextFieldBackgroundView = UIView().then {
     $0.clipsToBounds = true
     $0.layer.cornerRadius = 8.0
-    $0.layer.borderColor = Constants.baseColor?.cgColor
+    $0.layer.borderColor = Constants.baseColor.cgColor
     $0.layer.borderWidth = 1.0
   }
 
@@ -43,7 +48,7 @@ class NoteContentCell: BaseTableViewCell, View {
     $0.font = UIFont.systemFont(ofSize: 13, weight: .regular)
     $0.textColor = Constants.baseColor
     $0.contentVerticalAlignment = .top
-    $0.placeholder = Constants.contentPlaceHolderText
+    $0.attributedPlaceholder = Constants.contentPlaceHolderStyledText
   }
 
   func configure(reactor: Reactor) {

--- a/Tooda/Sources/Scenes/CreateNote/Cells/NoteContentCell.swift
+++ b/Tooda/Sources/Scenes/CreateNote/Cells/NoteContentCell.swift
@@ -11,6 +11,7 @@ import UIKit
 import ReactorKit
 import SnapKit
 import Then
+import UITextView_Placeholder
 
 class NoteContentCell: BaseTableViewCell, View {
   typealias Reactor = NoteContentCellReactor
@@ -44,10 +45,10 @@ class NoteContentCell: BaseTableViewCell, View {
     $0.layer.borderWidth = 1.0
   }
 
-  let contentTextField = UITextField().then {
+  let contentTextView = UITextView().then {
     $0.font = UIFont.systemFont(ofSize: 13, weight: .regular)
-    $0.textColor = Const.baseColor
-    $0.contentVerticalAlignment = .top
+    $0.textColor = Const.baseTextColor
+    $0.textAlignment = .left
     $0.attributedPlaceholder = Const.contentPlaceHolderStyledText
   }
 
@@ -70,7 +71,7 @@ class NoteContentCell: BaseTableViewCell, View {
       self.contentView.addSubview($0)
     }
 
-    [contentTextField].forEach {
+    [contentTextView].forEach {
       self.contentTextFieldBackgroundView.addSubview($0)
     }
   }
@@ -89,7 +90,7 @@ class NoteContentCell: BaseTableViewCell, View {
       $0.height.equalTo(169)
     }
 
-    contentTextField.snp.makeConstraints {
+    contentTextView.snp.makeConstraints {
       $0.top.equalToSuperview().offset(16)
       $0.left.equalToSuperview().offset(14)
       $0.right.equalToSuperview().offset(-14)

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
@@ -79,6 +79,10 @@ class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
 
   // MARK: UI-Properties
   
+  private let titleLabel = UILabel().then {
+    $0.attributedText = Date().string(.dot).styled(with: TextStyle.subTitle(color: .gray1))
+  }
+  
   private let closeBarbutton = UIBarButtonItem(image: UIImage(type: .iconCancelBlack),
                                                style: .plain,
                                                target: nil,
@@ -240,7 +244,7 @@ class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
 
 extension CreateNoteViewController {
   func configureNavigation() {
-    self.navigationItem.title = Date().description
+    self.navigationItem.titleView = self.titleLabel
     self.navigationItem.leftBarButtonItem = self.closeBarbutton
   }
   

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -233,8 +233,8 @@ let createDiarySectionFactory: CreateNoteSectionType = { authorization, coordina
     NoteSection(identity: .content, items: []),
     NoteSection(identity: .stock, items: []),
     NoteSection(identity: .addStock, items: []),
-    NoteSection(identity: .image, items: []),
-    NoteSection(identity: .link, items: [])
+    NoteSection(identity: .link, items: []),
+    NoteSection(identity: .image, items: [])
   ]
 
   let contentReactor: NoteContentCellReactor = NoteContentCellReactor()

--- a/Tooda/Sources/Scenes/CreateNote/Section/NoteSection.swift
+++ b/Tooda/Sources/Scenes/CreateNote/Section/NoteSection.swift
@@ -13,8 +13,8 @@ struct NoteSection {
     case content
     case stock
     case addStock
-    case image
     case link
+    case image
   }
   let identity: Identity
   var items: [NoteSectionItem]


### PR DESCRIPTION
### 수정내역 (필수)
1. NoteSection Identity의 순서를 Figma에 보여지는 순서에 맞게 변경했어요.
2. `NoteContentCell` 의 private enum의 이름을 **Const**로 변경했어요. 그리고 화면에 사용할 상수 값을 정의했어요.
3. `NoteContentCell`의 제목 입력 필를 기본 UITextField로 변경하고 UI 코드를 Figma에 맞게 변경했어요.
4. `NoteContentCell`의 내용 필드를 UITextView로 변경하고 UI코드를 적용했어요.
5. `NoteContentCell`의 TextField와 UITextView Delegate를 연결하고, Extension 메소드를 구현했어요.
6. **종목기록하기**셀 의 layer border cornerRadius를 제거했어요.
6. **노트등록화면**의 타이틀을 커스텀 UILabel로 변경하고, 화면에 보여지는 DateString의 포맷을 변경했어요.

### 스크린샷 (선택사항)
|**변경 전**|**변경 후**|
|------------|-----------|
|<img src="https://user-images.githubusercontent.com/19662529/148544607-3b9034dd-e369-4a39-b5a1-38b863383337.png" width=320>|<img src="https://user-images.githubusercontent.com/19662529/148544601-735b7f98-5c20-4ebc-ab56-02239d67decd.png" width=320>|
