### PR TITLE
[UI] 노트 등록 화면에 "등록" 버튼을 볼 수 있어요.

### DIFF
--- a/Tooda/Sources/Scenes/CreateNote/Cells/NoteContentCell.swift
+++ b/Tooda/Sources/Scenes/CreateNote/Cells/NoteContentCell.swift
@@ -129,3 +129,14 @@ extension NoteContentCell: UITextViewDelegate {
       .shouldTextInMaxLength(propertyValue: textView.text, range: range, replace: text)
   }
 }
+
+// MARK: - Reactive Extension
+
+extension Reactive where Base: NoteContentCell {
+  var textValueDidChanged: Observable<(String, String)> {
+    return Observable.combineLatest(
+      self.base.titleTextField.rx.text.orEmpty.asObservable(),
+      self.base.contentTextView.rx.text.orEmpty.asObservable()
+    )
+  }
+}

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
@@ -87,6 +87,13 @@ class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
                                                style: .plain,
                                                target: nil,
                                                action: nil)
+  
+  private let registerButton = BaseButton(width: 53, height: 28).then {
+    $0.setButtonTitle(with: "등록", style: TextStyle.body2Bold(color: UIColor.white))
+    $0.configureShadow(color: .clear, x: 0, y: 0, blur: 0, spread: 0)
+  }
+  
+  private lazy var rightBarButton = UIBarButtonItem(customView: self.registerButton)
 
   private lazy var tableView = UITableView().then {
     $0.separatorStyle = .none
@@ -246,6 +253,7 @@ extension CreateNoteViewController {
   func configureNavigation() {
     self.navigationItem.titleView = self.titleLabel
     self.navigationItem.leftBarButtonItem = self.closeBarbutton
+    self.navigationItem.rightBarButtonItem = self.rightBarButton
   }
   
   private func configureTapGesture() {

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
@@ -46,7 +46,6 @@ class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
       cell.configure(reactor: reactor)
         
       cell.rx.textValueDidChanged
-        .filter { !($0.0.isEmpty && $0.1.isEmpty) }
         .map { (title: $0.0, content: $0.1) }
         .bind(to: self.rxTextDidChangedRelay)
         .disposed(by: cell.disposeBag)

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
@@ -244,6 +244,13 @@ class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
       .drive(onNext: { [weak self] in
         self?.present(by: $0)
       }).disposed(by: self.disposeBag)
+    
+    reactor.state
+      .map { $0.shouldReigsterButtonEnabled }
+      .asDriver(onErrorJustReturn: false)
+      .drive(onNext: { [weak self] in
+        self?.registerButton.setOnOff(isOn: $0)
+      }).disposed(by: self.disposeBag)
   }
 }
 

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -85,7 +85,7 @@ final class CreateNoteViewReactor: Reactor {
     case .linkURLDidAdded(let url):
       return self.makeLinkSectionItem(url)
     case .textValueDidChanged(let title, let content):
-      return self.textValueDidChanged(title, content)
+      return self.makeTitleAndContent(title, content)
     case .dismissView:
         return dismissView()
     default:
@@ -235,11 +235,12 @@ extension CreateNoteViewReactor {
 
 // MARK: TextInput DidChanged
 extension CreateNoteViewReactor {
-  private func textValueDidChanged(_ title: String, _ content: String) -> Observable<Mutation> {
+  private func makeTitleAndContent(_ title: String, _ content: String) -> Observable<Mutation> {
     
     let shouldButtonEnabled = !(title.isEmpty || content.isEmpty)
     
-    return .concat([.just(.shouldRegisterButtonEnabeld(shouldButtonEnabled))])
+    // TODO: 노트 등록을 위한 title과 content를 State에 전달할 Mutation을 연결할 예정이에요.
+    return .just(.shouldRegisterButtonEnabeld(shouldButtonEnabled))
   }
 }
 

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -38,6 +38,7 @@ final class CreateNoteViewReactor: Reactor {
     case showAddStockView
     case stockItemDidAdded(NoteStock)
     case linkURLDidAdded(String)
+    case textValueDidChanged(title: String, content: String)
   }
 
   enum Mutation {
@@ -46,6 +47,7 @@ final class CreateNoteViewReactor: Reactor {
     case fetchImageSection(NoteSectionItem)
     case fetchStockSection(NoteSectionItem)
     case fetchLinkSection(NoteSectionItem)
+    case shouldRegisterButtonEnabeld(Bool)
   }
 
   struct State: Then {
@@ -82,6 +84,8 @@ final class CreateNoteViewReactor: Reactor {
       return self.makeStockSectionItem(stock)
     case .linkURLDidAdded(let url):
       return self.makeLinkSectionItem(url)
+    case .textValueDidChanged(let title, let content):
+      return self.textValueDidChanged(title, content)
     case .dismissView:
         return dismissView()
     default:
@@ -107,6 +111,8 @@ final class CreateNoteViewReactor: Reactor {
       newState.sections[NoteSection.Identity.stock.rawValue].items.append(sectionItem)
     case .fetchLinkSection(let sectionItem):
       newState.sections[NoteSection.Identity.link.rawValue].items.append(sectionItem)
+    case .shouldRegisterButtonEnabeld(let enabled):
+      newState.shouldReigsterButtonEnabled = enabled
     }
 
     return newState
@@ -224,6 +230,13 @@ extension CreateNoteViewReactor {
     let linkSectionItem: NoteSectionItem = NoteSectionItem.link(linkReactor)
     
     return .just(.fetchLinkSection(linkSectionItem))
+  }
+}
+
+// MARK: TextInput DidChanged
+extension CreateNoteViewReactor {
+  private func textValueDidChanged(_ title: String, _ content: String) -> Observable<Mutation> {
+    return .concat([.just(.shouldRegisterButtonEnabeld(!title.isEmpty))])
   }
 }
 

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -51,6 +51,7 @@ final class CreateNoteViewReactor: Reactor {
   struct State: Then {
     var sections: [NoteSection] = []
     var presentType: ViewPresentType?
+    var shouldReigsterButtonEnabled: Bool = false
   }
 
   let initialState: State

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -236,7 +236,10 @@ extension CreateNoteViewReactor {
 // MARK: TextInput DidChanged
 extension CreateNoteViewReactor {
   private func textValueDidChanged(_ title: String, _ content: String) -> Observable<Mutation> {
-    return .concat([.just(.shouldRegisterButtonEnabeld(!title.isEmpty))])
+    
+    let shouldButtonEnabled = !(title.isEmpty || content.isEmpty)
+    
+    return .concat([.just(.shouldRegisterButtonEnabeld(shouldButtonEnabled))])
   }
 }
 


### PR DESCRIPTION
### 수정내역 (필수)
1. 등록 버튼을 추가하고 **노트등록화면**의 우측 상단 버튼에 연결했어요.
2. `NoteContentCell` 에서 textField와 textView의 입력을 전달받을 Reactive Extension property 구현했어요.
3. 노트 등록 Reactor에서 `NoteContentCell`의 타이틀과 내용 값이 변경되면 등록 버튼의 활성화 여부를 처리하기 위한 Action, Mutation을 정의하고 State에 프로퍼티를 추가했어요.
4. 노트 등록 화면에서 2번의 스트림을 `rxTextDidChangedRelay`에 바인딩하는 코드를 추가했어요. 또한 `rxTextDidChangedRelay` 에서 3번 Action으로 바인딩 하는 코드도 추가했어요.

### 스크린샷 (선택사항)
![ezgif com-gif-maker (8)](https://user-images.githubusercontent.com/19662529/148561868-d7853514-4231-48d7-8324-c4601abeccd0.gif)
