### PR TITLE
[Domain] 노트 등록 화면의 각종 이벤트의 네이밍을 변경했어요.

### DIFF
--- a/Tooda/Sources/Scenes/CreateNote/Cells/NoteContentCell.swift
+++ b/Tooda/Sources/Scenes/CreateNote/Cells/NoteContentCell.swift
@@ -133,7 +133,7 @@ extension NoteContentCell: UITextViewDelegate {
 // MARK: - Reactive Extension
 
 extension Reactive where Base: NoteContentCell {
-  var textValueDidChanged: Observable<(String, String)> {
+  var combinedTextDidChanged: Observable<(String, String)> {
     return Observable.combineLatest(
       self.base.titleTextField.rx.text.orEmpty.asObservable(),
       self.base.contentTextView.rx.text.orEmpty.asObservable()

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
@@ -234,7 +234,7 @@ class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
       .disposed(by: self.disposeBag)
     
     rxCombinedTextDidChangedRelay
-      .map { Reactor.Action.textValueDidChanged(title: $0.title, content: $0.content)}
+      .map { Reactor.Action.makeTitleAndContent(title: $0.title, content: $0.content)}
       .bind(to: reactor.action)
       .disposed(by: self.disposeBag)
     

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
@@ -30,7 +30,7 @@ class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
   
   let rxAddStockDidTapRelay: PublishRelay<Void> = PublishRelay()
   
-  private let rxTextDidChangedRelay: PublishRelay<(title: String, content: String)> = PublishRelay()
+  private let rxCombinedTextDidChangedRelay: PublishRelay<(title: String, content: String)> = PublishRelay()
   
   // MARK: Properties
   lazy var dataSource: Section = Section(configureCell: { _, tableView, indexPath, item -> UITableViewCell in
@@ -39,9 +39,9 @@ class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
       let cell = tableView.dequeue(NoteContentCell.self, indexPath: indexPath)
       cell.configure(reactor: reactor)
         
-      cell.rx.textValueDidChanged
+      cell.rx.combinedTextDidChanged
         .map { (title: $0.0, content: $0.1) }
-        .bind(to: self.rxTextDidChangedRelay)
+        .bind(to: self.rxCombinedTextDidChangedRelay)
         .disposed(by: cell.disposeBag)
         
       return cell
@@ -233,7 +233,7 @@ class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
       .bind(to: reactor.action)
       .disposed(by: self.disposeBag)
     
-    rxTextDidChangedRelay
+    rxCombinedTextDidChangedRelay
       .map { Reactor.Action.textValueDidChanged(title: $0.title, content: $0.content)}
       .bind(to: reactor.action)
       .disposed(by: self.disposeBag)

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -38,7 +38,7 @@ final class CreateNoteViewReactor: Reactor {
     case showAddStockView
     case stockItemDidAdded(NoteStock)
     case linkURLDidAdded(String)
-    case textValueDidChanged(title: String, content: String)
+    case makeTitleAndContent(title: String, content: String)
     case linkButtonDidTapped
   }
 
@@ -89,7 +89,7 @@ final class CreateNoteViewReactor: Reactor {
       return self.makeStockSectionItem(stock)
     case .linkURLDidAdded(let url):
       return self.makeLinkSectionItem(url)
-    case .textValueDidChanged(let title, let content):
+    case .makeTitleAndContent(let title, let content):
       return self.makeTitleAndContent(title, content)
     case .linkButtonDidTapped:
         return self.linkButtonDidTapped()


### PR DESCRIPTION
### 수정내역 (필수)
- `NoteContentCell` 의 Reactive Extension value에 comined prefix가 붙게 네이밍을 변경했어요.
- `CreateNoteViewController`에서 제목, 내용을 바인딩하는 PublishRelay의 네이밍을 변경했어요.
- `CreateNoteReactor`에서 제목, 내용을 전달받는 Action case의 이름을 변경했어요.
