### PR TITLE
[Domain] 노트 가이드 뷰화면에 표시된 날짜 텍스트를 노트 등록화면에서 볼 수 있어요.

### DIFF
--- a/Tooda/Sources/Core/AppFactory.swift
+++ b/Tooda/Sources/Core/AppFactory.swift
@@ -49,7 +49,7 @@ final class AppFactory: AppFactoryType {
           createDiarySectionFactory: createDiarySectionFactory)
       )
         
-      let viewController = CreateNoteViewController(reactor: reactor)
+      let viewController = CreateNoteViewController(dateString: today, reactor: reactor)
       let navigationController = UINavigationController(rootViewController: viewController)
       navigationController.modalPresentationStyle = .overFullScreen
       return navigationController

--- a/Tooda/Sources/Core/AppFactory.swift
+++ b/Tooda/Sources/Core/AppFactory.swift
@@ -38,7 +38,7 @@ final class AppFactory: AppFactoryType {
       )
       return HomeViewController(reactor: reactor)
 
-    case .createNote:
+    case .createNote(let today):
       let reactor = CreateNoteViewReactor(
         dependency: .init(
           service: self.dependency.appInject.resolve(NetworkingProtocol.self),

--- a/Tooda/Sources/Core/Coordinator/Scene.swift
+++ b/Tooda/Sources/Core/Coordinator/Scene.swift
@@ -15,7 +15,7 @@ import RxRelay
 enum Scene {
   case login
   case home
-  case createNote
+  case createNote(dateString: String)
   case settings
   case addStock(completion: PublishRelay<NoteStock>)
   case search

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
@@ -83,12 +83,13 @@ class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
         return cell
     }
   }, canEditRowAtIndexPath: { _, _ in true })
-
+  
+  private let dateString: String
 
   // MARK: UI-Properties
   
-  private let titleLabel = UILabel().then {
-    $0.attributedText = Date().string(.dot).styled(with: TextStyle.subTitle(color: .gray1))
+  private lazy var titleLabel = UILabel().then {
+    $0.attributedText = self.dateString.styled(with: TextStyle.subTitle(color: .gray1))
   }
   
   private let closeBarbutton = UIBarButtonItem(image: UIImage(type: .iconCancelBlack),
@@ -144,10 +145,12 @@ class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
     fatalError("init(coder:) has not been implemented")
   }
 
-  init(reactor: Reactor) {
+  init(dateString: String, reactor: Reactor) {
     defer {
       self.reactor = reactor
     }
+    
+    self.dateString = dateString
     super.init()
   }
   

--- a/Tooda/Sources/Scenes/CreateNote/View/CreateNoteGuideView.swift
+++ b/Tooda/Sources/Scenes/CreateNote/View/CreateNoteGuideView.swift
@@ -30,6 +30,8 @@ final class CreateNoteGuideView: UIView {
   
   weak var delegate: CreateNoteGuideViewDelegate?
   
+  private var todayString: String = Date().string(.dot)
+  
   let contentView = UIView().then {
     $0.layer.masksToBounds = false
   }
@@ -74,7 +76,7 @@ final class CreateNoteGuideView: UIView {
   private func configureUI() {
     
     self.titleLabel.do {
-      $0.attributedText = Date().string(.dot).styled(with: Font.date)
+      $0.attributedText = self.todayString.styled(with: Font.date)
     }
     
     self.addSubview(contentView)

--- a/Tooda/Sources/Scenes/CreateNote/View/CreateNoteGuideView.swift
+++ b/Tooda/Sources/Scenes/CreateNote/View/CreateNoteGuideView.swift
@@ -11,7 +11,7 @@ import Then
 import SnapKit
 
 protocol CreateNoteGuideViewDelegate: AnyObject {
-  func contentDidTapped()
+  func contentDidTapped(dateString: String)
 }
 
 final class CreateNoteGuideView: UIView {
@@ -121,7 +121,7 @@ final class CreateNoteGuideView: UIView {
   
   @objc
   private func contentViewDidTapped(_ sender: Any?) {
-    self.delegate?.contentDidTapped()
+    self.delegate?.contentDidTapped(dateString: self.todayString)
   }
   
   private func applyGradientAndShadow(_ view: UIView) {

--- a/Tooda/Sources/Scenes/Home/HomeReactor.swift
+++ b/Tooda/Sources/Scenes/Home/HomeReactor.swift
@@ -31,7 +31,7 @@ final class HomeReactor: Reactor {
     // routing
     case pushSearch
     case pushSettings
-    case presentCreateNote
+    case presentCreateNote(dateString: String)
   }
 
   enum Mutation {
@@ -121,8 +121,8 @@ extension HomeReactor {
     case .pushSettings:
       pushSettings()
       return Observable<Mutation>.empty()
-    case .presentCreateNote:
-      presentCreateNote()
+    case .presentCreateNote(let today):
+      presentCreateNote(today)
       return Observable<Mutation>.empty()
     }
   }
@@ -275,10 +275,9 @@ extension HomeReactor {
     )
   }
   
-  private func presentCreateNote() {
-    // FIXME: dateString에 실제 값을 전달해요.
+  private func presentCreateNote(_ dateString: String) {
     self.dependency.coordinator.transition(
-      to: .createNote(dateString: ""),
+      to: .createNote(dateString: dateString),
       using: .modal,
       animated: true,
       completion: nil

--- a/Tooda/Sources/Scenes/Home/HomeReactor.swift
+++ b/Tooda/Sources/Scenes/Home/HomeReactor.swift
@@ -276,8 +276,9 @@ extension HomeReactor {
   }
   
   private func presentCreateNote() {
+    // FIXME: dateString에 실제 값을 전달해요.
     self.dependency.coordinator.transition(
-      to: .createNote,
+      to: .createNote(dateString: ""),
       using: .modal,
       animated: true,
       completion: nil

--- a/Tooda/Sources/Scenes/Home/HomeViewController.swift
+++ b/Tooda/Sources/Scenes/Home/HomeViewController.swift
@@ -86,7 +86,7 @@ final class HomeViewController: BaseViewController<HomeReactor> {
 
   private let rxScrollToItem = BehaviorRelay<Int>(value: 0)
   private let rxPickDate = PublishRelay<Date>()
-  private let rxNoteGuideViewTap = PublishRelay<Void>()
+  private let rxNoteGuideViewTap = PublishRelay<String>()
 
   // MARK: Initializing
 
@@ -138,7 +138,7 @@ final class HomeViewController: BaseViewController<HomeReactor> {
     
     self.rxNoteGuideViewTap
       .asObservable()
-      .map { HomeReactor.Action.presentCreateNote }
+      .map { HomeReactor.Action.presentCreateNote(dateString: $0) }
       .bind(to: reactor.action)
       .disposed(by: self.disposeBag)
 
@@ -322,7 +322,7 @@ extension HomeViewController: UICollectionViewDelegateFlowLayout {
 // MARK: - CreateNoteGuideViewDelegate
 
 extension HomeViewController: CreateNoteGuideViewDelegate {
-  func contentDidTapped() {
-    self.rxNoteGuideViewTap.accept(())
+  func contentDidTapped(dateString: String) {
+    self.rxNoteGuideViewTap.accept(dateString)
   }
 }


### PR DESCRIPTION
### 수정내역 (필수)
- `Scene`의 CreateNote case에 DateString 파라미터를 추가했어요.
- Scene이 변경됨에 따라 `AppFactory`와 `HomeReactor`의 연결된 코드가 변경되었어요.
-`NoteGuideView`에 TodayString 프로퍼티를 추가했어요.
- `NoteGuideViewTapDelegate`에서 탭 메소드에 dateString 파라미터를 추가했어요.
- `HomeViewController`의 rxNoteGuideViewTap와 Delegate 메소드의 파라미터 타입을 변경했어요.
- `HomeReactor`에서 노트 등록화면을 호출할 때 DateString을 전달받기 위한 Reactor Action Command와 메소드에 파라미터를 정의했어요.
