### PR TITLE
[Entity/Utils] 노트 관련 Entities를 변경하고 유용한 Extension을 추가했어요.

### DIFF
--- a/Tooda/Sources/Common/Extensions/Array+Extension.swift
+++ b/Tooda/Sources/Common/Extensions/Array+Extension.swift
@@ -13,3 +13,9 @@ extension Array {
     return indices ~= index ? self[index] : nil
   }
 }
+
+extension Collection {
+  var isNotEmpty: Bool {
+    return !self.isEmpty
+  }
+}

--- a/Tooda/Sources/Entities/Note/AddNoteDTO.swift
+++ b/Tooda/Sources/Entities/Note/AddNoteDTO.swift
@@ -10,13 +10,23 @@ import Foundation
 struct AddNoteDTO {
   var title: String
   var content: String
-  var stocks: [NoteStock]?
-  var links: [String]?
-  var images: [String]?
+  var stocks: [NoteStock]
+  var links: [String]
+  var images: [String]
   var sticker: Sticker
 }
 
 extension AddNoteDTO {
+  
+  init() {
+    title = ""
+    content = ""
+    stocks = []
+    links = []
+    images = []
+    sticker = .wow
+  }
+  
   func asBodyParameters() -> [String: Any] {
     var parameters: [String: Any] = [:]
     
@@ -26,19 +36,19 @@ extension AddNoteDTO {
       "sticker": sticker
     ])
     
-    if let stocks = stocks {
+    if stocks.isNotEmpty {
       parameters.concat(dict: [
         "stocks": stocks
       ])
     }
     
-    if let links = links {
+    if links.isNotEmpty {
       parameters.concat(dict: [
         "links": links
       ])
     }
     
-    if let images = images {
+    if images.isNotEmpty {
       parameters.concat(dict: [
         "images": images
       ])

--- a/Tooda/Sources/Entities/Note/NoteStock.swift
+++ b/Tooda/Sources/Entities/Note/NoteStock.swift
@@ -10,9 +10,9 @@ import Foundation
 import UIKit
 
 enum StockChangeState: String, Codable {
-	case rise
-	case even
-	case fall
+  case rise = "RISE"
+  case even = "EVEN"
+  case fall = "FALL"
 }
 
 extension StockChangeState {


### PR DESCRIPTION
### 수정내역 (필수)
- Collection Type에서 사용할 수 있는 isNotEmpty Extension을 추가했어요
```
func aa() -> Bool {
    return "aa".isNotEmpty
}

let result = ["a", "b", "c"].isNotEmpty
```
- StockChangeState를 사용하는 Entitiy를 파싱하는 과정에서 에러가 발생해 case에 rawValue를 별도로 지정해줬어요.
- AddNoteDTO의 프로퍼티중 프로퍼티 타입에서 옵셔널을 제거했어요.
