### PR TITLE
[Domain] 노트 등록 화면에서 입력한 정보를 등록할 수 있어요.

### DIFF
--- a/Tooda/Sources/Entities/Note/AddNoteDTO.swift
+++ b/Tooda/Sources/Entities/Note/AddNoteDTO.swift
@@ -33,12 +33,12 @@ extension AddNoteDTO {
     parameters.concat(dict: [
       "title": title,
       "content": content,
-      "sticker": sticker
+      "sticker": sticker.rawValue
     ])
     
     if stocks.isNotEmpty {
       parameters.concat(dict: [
-        "stocks": stocks
+        "stocks": stocks.map { $0.asParameter() }
       ])
     }
     

--- a/Tooda/Sources/Entities/Note/NoteStock.swift
+++ b/Tooda/Sources/Entities/Note/NoteStock.swift
@@ -45,3 +45,27 @@ struct NoteStock: Codable {
 	var change: StockChangeState?
 	var changeRate: Float?
 }
+
+extension NoteStock {
+  func asParameter() -> [String: Any] {
+    var parameters: [String: Any] = [:]
+    
+    parameters.concat(dict: [
+      "name": name
+    ])
+    
+    if let change = change {
+      parameters.concat(dict: [
+        "change": change.rawValue.uppercased()
+      ])
+    }
+    
+    if let changeRate = changeRate {
+      parameters.concat(dict: [
+        "changeRate": changeRate
+      ])
+    }
+    
+    return parameters
+  }
+}

--- a/Tooda/Sources/Networking/API/NoteAPI.swift
+++ b/Tooda/Sources/Networking/API/NoteAPI.swift
@@ -22,7 +22,7 @@ extension NoteAPI: BaseAPI {
   var path: String {
     switch self {
       case .create:
-        return "/diary"
+        return "diary"
       case .list:
         return "diary"
       case .addImage:

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
@@ -218,6 +218,11 @@ class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
       .bind(to: reactor.action)
       .disposed(by: self.disposeBag)
     
+    self.registerButton.rx.tap
+      .map { _ in Reactor.Action.registerButtonDidTapped }
+      .bind(to: reactor.action)
+      .disposed(by: self.disposeBag)
+    
     imageItemCellDidTapRelay
       .map { Reactor.Action.didSelectedImageItem($0) }
       .bind(to: reactor.action)

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -40,6 +40,7 @@ final class CreateNoteViewReactor: Reactor {
     case linkURLDidAdded(String)
     case makeTitleAndContent(title: String, content: String)
     case linkButtonDidTapped
+    case registerButtonDidTapped
   }
 
   enum Mutation {
@@ -67,6 +68,7 @@ final class CreateNoteViewReactor: Reactor {
   
   private let addLinkURLCompletionRelay: PublishRelay<String> = PublishRelay()
 
+  private let addStickerCompletionRelay: PublishRelay<Sticker> = PublishRelay()
   init(dependency: Dependency) {
     self.dependency = dependency
     self.initialState = State()
@@ -93,6 +95,8 @@ final class CreateNoteViewReactor: Reactor {
       return self.makeTitleAndContent(title, content)
     case .linkButtonDidTapped:
         return self.linkButtonDidTapped()
+    case .registerButtonDidTapped:
+        return self.registerButtonDidTapped()
     case .dismissView:
         return dismissView()
     default:
@@ -263,6 +267,14 @@ extension CreateNoteViewReactor {
   }
 }
 
+extension CreateNoteViewReactor {
+  private func registerButtonDidTapped() -> Observable<Mutation> {
+    
+    self.dependency.coordinator.transition(to: .popUp(type: .list(self.addStickerCompletionRelay)), using: .modal, animated: false, completion: nil)
+    
+    return .empty()
+  }
+}
 typealias CreateNoteSectionType = (AppAuthorizationType, AppCoordinatorType) -> [NoteSection]
 
 let createDiarySectionFactory: CreateNoteSectionType = { authorization, coordinator -> [NoteSection] in

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -67,11 +67,12 @@ final class CreateNoteViewReactor: Reactor {
 
   let dependency: Dependency
   
-  private let addStockCompletionRelay: PublishRelay<NoteStock> = PublishRelay()
+  // MARK: Global Events
   
+  private let addStockCompletionRelay: PublishRelay<NoteStock> = PublishRelay()
   private let addLinkURLCompletionRelay: PublishRelay<String> = PublishRelay()
-
   private let addStickerCompletionRelay: PublishRelay<Sticker> = PublishRelay()
+  
   init(dependency: Dependency) {
     self.dependency = dependency
     self.initialState = State()
@@ -85,8 +86,8 @@ final class CreateNoteViewReactor: Reactor {
       return checkAuthorizationAndSelectedItem(indexPath: index)
     case .uploadImage(let data):
       return self.uploadImage(data)
-        .flatMap { [weak self] response -> Observable<Mutation> in
-        return self?.fetchImageSection(with: response) ?? .empty()
+        .flatMap { [weak self] imageURL -> Observable<Mutation> in
+          return self?.fetchImageSection(with: imageURL) ?? .empty()
       }
     case .showAddStockView:
       return presentAddStockView()

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -57,6 +57,8 @@ final class CreateNoteViewReactor: Reactor {
     var presentType: ViewPresentType?
     var shouldReigsterButtonEnabled: Bool = false
   }
+  
+  private var addNoteDTO: AddNoteDTO = AddNoteDTO()
 
   let initialState: State
   
@@ -214,6 +216,8 @@ extension CreateNoteViewReactor {
 
 
     imageCellReactor.action.onNext(.addImage(imageURL))
+    
+    self.addNoteDTO.images.append(imageURL)
 
     return .empty()
   }
@@ -230,6 +234,8 @@ extension CreateNoteViewReactor {
     
     let sectionItem = NoteSectionItem.stock(reator)
     
+    self.addNoteDTO.stocks.append(stock)
+    
     return .just(.fetchStockSection(sectionItem))
   }
   
@@ -241,6 +247,8 @@ extension CreateNoteViewReactor {
     
     let linkSectionItem: NoteSectionItem = NoteSectionItem.link(linkReactor)
     
+    self.addNoteDTO.links.append(url)
+    
     return .just(.fetchLinkSection(linkSectionItem))
   }
 }
@@ -251,7 +259,9 @@ extension CreateNoteViewReactor {
     
     let shouldButtonEnabled = !(title.isEmpty || content.isEmpty)
     
-    // TODO: 노트 등록을 위한 title과 content를 State에 전달할 Mutation을 연결할 예정이에요.
+    self.addNoteDTO.title = title
+    self.addNoteDTO.content = content
+    
     return .just(.shouldRegisterButtonEnabeld(shouldButtonEnabled))
   }
 }


### PR DESCRIPTION
### 수정내역 (필수)
- NoteStock을 parameter로 전달하기 위해 extension value를 추가했어요.
- AddNoteDTO에서 asParameter 메소드에서 sticker와 stocks를 전달 로직을 변경했어요.
- 노트 등록 Reactor에서 
- 노트 등록 화면에서 활성화 상태인 등록 버튼을 탭하면 한줄평 팝업을 호출해요. 한줄평 팝업의 이벤트를 전달받기 위해 Reactor에 별도 Relay를 추가하고 Action Transform에 추가했어요.
- 한줄평 팝업에서 스티커 선택이 끝나면 노트 등록 API를 호출해요. 노트 등록 API가 성공하고 Note Entity의 값에 따라 화면을 내려주도록 해요.
- 노트 입력 데이터를 저장하기 위해 Reactor에 addNoteDTO를 멤버변수로 정의하고, Action에서 전달되는 데이터를 Mutation Function 메소드에서 사이드 이펙트로 데이터를 변경시켜요.

### 스크린샷 (선택사항)
![ezgif com-gif-maker (3)](https://user-images.githubusercontent.com/19662529/148668222-6f8cf852-a5d9-411a-9553-c8a9c6d15fd8.gif)

### TODO:
- [ ] : 노트 등록 API 호출간 인디케이터를 추가해서 사용자에게 지연시간이 소요됨을 인지시켜요.
- [ ] : 노트 이미지 업로드 시, 이미지 셀에 데이터 로딩간에 Indicator를 추가해요.