### PR TITLE
[UI] NoteListCell에서 shadow가 짤리는 이슈를 수정했어요

### DIFF
--- a/Tooda/Sources/Scenes/NoteList/Cells/NoteListCell.swift
+++ b/Tooda/Sources/Scenes/NoteList/Cells/NoteListCell.swift
@@ -25,10 +25,14 @@ final class NoteListCell: BaseTableViewCell {
   private let cardView = UIView().then {
     $0.backgroundColor = .white
     $0.layer.cornerRadius = 8
-    $0.layer.shadowOffset = CGSize(width: 0, height: 8)
-    $0.layer.shadowOpacity = 1
-    $0.layer.shadowRadius = 20
-    $0.layer.shadowColor = UIColor.gray6.withAlphaComponent(0.12).cgColor
+    $0.configureShadow(
+      color: UIColor.gray6.withAlphaComponent(0.12),
+      alpha: 1,
+      x: 0,
+      y: 8,
+      blur: 40,
+      spread: 0
+    )
   }
   
   private let emojiImageView = UIImageView().then {
@@ -62,8 +66,8 @@ final class NoteListCell: BaseTableViewCell {
   
   override func configureUI() {
     super.configureUI()
+    backgroundColor = .clear
     contentView.do {
-      $0.backgroundColor = .gray5
       $0.addSubview(cardView)
     }
     


### PR DESCRIPTION
### 수정내역 (필수)
- NoteListCell에서 shadow가 짤리는 이슈를 수정

### 스크린샷 (선택사항)
- Before & After


<div>
<img width="340" alt="스크린샷 2022-01-02 오후 11 34 10" src="https://user-images.githubusercontent.com/31857308/148691014-f885460d-c034-45b0-9ed7-3f4f76b0a751.png">

<img width="340" alt="스크린샷 2022-01-02 오후 11 34 13" src="https://user-images.githubusercontent.com/31857308/148691035-f02dc075-45c3-4b7a-8c8f-7b2e8143aff4.png">
</div>


