### PR TITLE
[Domain] 노트 등록 화면에서 종목 아이템을 수정하거나 삭제할 수 있어요.

### DIFF
--- a/Tooda/Sources/Core/AppFactory.swift
+++ b/Tooda/Sources/Core/AppFactory.swift
@@ -131,10 +131,6 @@ final class AppFactory: AppFactoryType {
         
       let viewController = StockRateInputViewController(reactor: reactor, editMode: editMode)
         
-      if editMode == .input {
-        viewController.modalPresentationStyle = .overFullScreen
-      }
-        
       return viewController
 
     case .popUp(let type):

--- a/Tooda/Sources/Core/AppFactory.swift
+++ b/Tooda/Sources/Core/AppFactory.swift
@@ -124,14 +124,14 @@ final class AppFactory: AppFactoryType {
       )
 
       return SearchRecentViewController(reactor: reactor)
-    case .stockRateInput(let payload, let isEditable):
+    case .stockRateInput(let payload, let editMode):
         let reactor = StockRateInputReactor(dependency: .init(
         coordinator: self.dependency.appInject.resolve(AppCoordinatorType.self)),
                                             payload: payload)
         
-      let viewController = StockRateInputViewController(reactor: reactor, isEditable: isEditable)
+      let viewController = StockRateInputViewController(reactor: reactor, editMode: editMode)
         
-      if isEditable {
+      if editMode == .input {
         viewController.modalPresentationStyle = .overFullScreen
       }
         

--- a/Tooda/Sources/Core/AppFactory.swift
+++ b/Tooda/Sources/Core/AppFactory.swift
@@ -124,11 +124,18 @@ final class AppFactory: AppFactoryType {
       )
 
       return SearchRecentViewController(reactor: reactor)
-    case .stockRateInput(let payload):
+    case .stockRateInput(let payload, let isEditable):
         let reactor = StockRateInputReactor(dependency: .init(
         coordinator: self.dependency.appInject.resolve(AppCoordinatorType.self)),
                                             payload: payload)
-      return StockRateInputViewController(reactor: reactor)
+        
+      let viewController = StockRateInputViewController(reactor: reactor, isEditable: isEditable)
+        
+      if isEditable {
+        viewController.modalPresentationStyle = .overFullScreen
+      }
+        
+      return viewController
 
     case .popUp(let type):
       let reactor = PopUpReactor(

--- a/Tooda/Sources/Core/Coordinator/Scene.swift
+++ b/Tooda/Sources/Core/Coordinator/Scene.swift
@@ -21,7 +21,7 @@ enum Scene {
   case search
   case noteList(payload: NoteListViewController.Payload)
   case searchRecent
-  case stockRateInput(payload: StockRateInputReactor.Payload)
+  case stockRateInput(payload: StockRateInputReactor.Payload, isEditable: Bool = false)
   case popUp(type: PopUpReactor.PopUpType)
   case searchResult
   case noteDetail

--- a/Tooda/Sources/Core/Coordinator/Scene.swift
+++ b/Tooda/Sources/Core/Coordinator/Scene.swift
@@ -21,7 +21,7 @@ enum Scene {
   case search
   case noteList(payload: NoteListViewController.Payload)
   case searchRecent
-  case stockRateInput(payload: StockRateInputReactor.Payload, isEditable: Bool = false)
+  case stockRateInput(payload: StockRateInputReactor.Payload, editMode: StockRateInputViewController.EditMode = .input)
   case popUp(type: PopUpReactor.PopUpType)
   case searchResult
   case noteDetail

--- a/Tooda/Sources/Scenes/AddStock/StockRateInputViewController.swift
+++ b/Tooda/Sources/Scenes/AddStock/StockRateInputViewController.swift
@@ -16,6 +16,11 @@ class StockRateInputViewController: BaseViewController<StockRateInputReactor> {
   
   // MARK: Enum
   
+  enum EditMode {
+    case input
+    case modify
+  }
+  
   private enum Font {
     static let title = TextStyle.titleBold(color: .gray1)
     static let descprtion = TextStyle.body(color: .gray3)

--- a/Tooda/Sources/Scenes/AddStock/StockRateInputViewController.swift
+++ b/Tooda/Sources/Scenes/AddStock/StockRateInputViewController.swift
@@ -44,6 +44,10 @@ class StockRateInputViewController: BaseViewController<StockRateInputReactor> {
   init(reactor: Reactor, editMode: EditMode) {
     defer {
       self.reactor = reactor
+      
+      if editMode == .modify {
+        self.modalPresentationStyle = .overFullScreen
+      }
     }
     
     self.editMode = editMode

--- a/Tooda/Sources/Scenes/AddStock/StockRateInputViewController.swift
+++ b/Tooda/Sources/Scenes/AddStock/StockRateInputViewController.swift
@@ -126,18 +126,13 @@ class StockRateInputViewController: BaseViewController<StockRateInputReactor> {
     
     self.buttonBackGroundView.addSubview(doneButton)
     
+    let buttonTitle = self.isEditable ? "수정".styled(with: Font.addButton) : "추가".styled(with: Font.addButton)
+    
     self.doneButton.do {
-      if self.isEditable {
-        $0.setAttributedTitle(
-          "수정".styled(with: Font.addButton),
-          for: .normal
-        )
-      } else {
-        $0.setAttributedTitle(
-          "추가".styled(with: Font.addButton),
-          for: .normal
-        )
-      }
+      $0.setAttributedTitle(
+        buttonTitle,
+        for: .normal
+      )
     }
   }
   

--- a/Tooda/Sources/Scenes/AddStock/StockRateInputViewController.swift
+++ b/Tooda/Sources/Scenes/AddStock/StockRateInputViewController.swift
@@ -34,10 +34,14 @@ class StockRateInputViewController: BaseViewController<StockRateInputReactor> {
     static let addButtonHeight: CGFloat = 48
   }
   
-  init(reactor: Reactor) {
+  private let isEditable: Bool
+  
+  init(reactor: Reactor, isEditable: Bool) {
     defer {
       self.reactor = reactor
     }
+    
+    self.isEditable = isEditable
     super.init()
   }
   
@@ -89,11 +93,6 @@ class StockRateInputViewController: BaseViewController<StockRateInputReactor> {
   }
   
   private let addButton = UIButton(type: .system).then {
-    $0.setAttributedTitle(
-      "추가".styled(with: Font.addButton),
-      for: .normal
-    )
-    
     $0.setBackgroundImage(UIColor.gray3.image(), for: .disabled)
     $0.setBackgroundImage(UIColor.mainGreen.image(), for: .normal)
     
@@ -126,6 +125,20 @@ class StockRateInputViewController: BaseViewController<StockRateInputReactor> {
     self.textFieldBackgroundView.addSubview(textField)
     
     self.buttonBackGroundView.addSubview(addButton)
+    
+    self.addButton.do {
+      if self.isEditable {
+        $0.setAttributedTitle(
+          "수정".styled(with: Font.addButton),
+          for: .normal
+        )
+      } else {
+        $0.setAttributedTitle(
+          "추가".styled(with: Font.addButton),
+          for: .normal
+        )
+      }
+    }
   }
   
   override func configureConstraints() {

--- a/Tooda/Sources/Scenes/AddStock/StockRateInputViewController.swift
+++ b/Tooda/Sources/Scenes/AddStock/StockRateInputViewController.swift
@@ -92,7 +92,7 @@ class StockRateInputViewController: BaseViewController<StockRateInputReactor> {
     $0.backgroundColor = UIColor(type: .white)
   }
   
-  private let addButton = UIButton(type: .system).then {
+  private let doneButton = UIButton(type: .system).then {
     $0.setBackgroundImage(UIColor.gray3.image(), for: .disabled)
     $0.setBackgroundImage(UIColor.mainGreen.image(), for: .normal)
     
@@ -124,9 +124,9 @@ class StockRateInputViewController: BaseViewController<StockRateInputReactor> {
     
     self.textFieldBackgroundView.addSubview(textField)
     
-    self.buttonBackGroundView.addSubview(addButton)
+    self.buttonBackGroundView.addSubview(doneButton)
     
-    self.addButton.do {
+    self.doneButton.do {
       if self.isEditable {
         $0.setAttributedTitle(
           "수정".styled(with: Font.addButton),
@@ -181,7 +181,7 @@ class StockRateInputViewController: BaseViewController<StockRateInputReactor> {
       $0.bottom.equalTo(self.view.keyboardLayoutGuide.snp.top)
     }
     
-    addButton.snp.makeConstraints {
+    doneButton.snp.makeConstraints {
       $0.top.equalToSuperview().offset(16)
       $0.left.right.equalToSuperview().inset(20)
       $0.bottom.equalToSuperview().offset(-24)
@@ -201,7 +201,7 @@ class StockRateInputViewController: BaseViewController<StockRateInputReactor> {
       .bind(to: reactor.action)
       .disposed(by: self.disposeBag)
     
-    self.addButton.rx.tap
+    self.doneButton.rx.tap
       .map { Reactor.Action.addButtonDidTapped }
       .bind(to: reactor.action)
       .disposed(by: self.disposeBag)
@@ -267,7 +267,7 @@ extension StockRateInputViewController {
   }
   
   private func addButtonDidChanged(_ isEnabled: Bool) {
-    self.addButton.isEnabled = isEnabled
+    self.doneButton.isEnabled = isEnabled
   }
   
   private func textFieldVisiblityDidChanged(by isEven: Bool) {

--- a/Tooda/Sources/Scenes/AddStock/StockRateInputViewController.swift
+++ b/Tooda/Sources/Scenes/AddStock/StockRateInputViewController.swift
@@ -39,14 +39,15 @@ class StockRateInputViewController: BaseViewController<StockRateInputReactor> {
     static let addButtonHeight: CGFloat = 48
   }
   
-  private let isEditable: Bool
+  private let editMode: EditMode
   
-  init(reactor: Reactor, isEditable: Bool) {
+  init(reactor: Reactor, editMode: EditMode) {
     defer {
       self.reactor = reactor
     }
     
-    self.isEditable = isEditable
+    self.editMode = editMode
+    
     super.init()
   }
   
@@ -131,7 +132,7 @@ class StockRateInputViewController: BaseViewController<StockRateInputReactor> {
     
     self.buttonBackGroundView.addSubview(doneButton)
     
-    let buttonTitle = self.isEditable ? "수정".styled(with: Font.addButton) : "추가".styled(with: Font.addButton)
+    let buttonTitle = self.editMode == .modify ? "수정".styled(with: Font.addButton) : "추가".styled(with: Font.addButton)
     
     self.doneButton.do {
       $0.setAttributedTitle(

--- a/Tooda/Sources/Scenes/CreateNote/Cells/Reactors/NoteStockCellReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/Cells/Reactors/NoteStockCellReactor.swift
@@ -10,11 +10,11 @@ import ReactorKit
 
 final class NoteStockCellReactor: Reactor {
   enum Action {
-
+    case payloadDidChanged(NoteStock)
   }
 
   enum Mutation {
-
+    case payloadDidChanged(NoteStock)
   }
 
   struct State {
@@ -35,11 +35,24 @@ final class NoteStockCellReactor: Reactor {
   }
 
   func mutate(action: Action) -> Observable<Mutation> {
+    
+    switch action {
+      case .payloadDidChanged(let stock):
+        return .just(.payloadDidChanged(stock))
+    }
+    
     return .empty()
   }
 
-  func reduce(state: State, mutation: Action) -> State {
+  func reduce(state: State, mutation: Mutation) -> State {
     var newState = state
+    
+    switch mutation {
+      case .payloadDidChanged(let stock):
+        newState.payload.name = stock.name
+        newState.payload.rate = stock.changeRate ?? 0.0
+    }
+    
     return newState
   }
 }

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
@@ -250,6 +250,10 @@ class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
       .bind(to: reactor.action)
       .disposed(by: self.disposeBag)
     
+    rxStockItemDeleteRelay
+      .map { Reactor.Action.stockItemDidDeleted($0) }
+      .bind(to: reactor.action)
+      .disposed(by: self.disposeBag)
     // State
     reactor.state
       .map { $0.sections }

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
@@ -254,6 +254,12 @@ class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
       .map { Reactor.Action.stockItemDidDeleted($0) }
       .bind(to: reactor.action)
       .disposed(by: self.disposeBag)
+    
+    rxStockItemDidEditRelay
+      .map { Reactor.Action.showStockItemEditView($0) }
+      .bind(to: reactor.action)
+      .disposed(by: self.disposeBag)
+    
     // State
     reactor.state
       .map { $0.sections }

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
@@ -30,6 +30,10 @@ class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
   
   let rxAddStockDidTapRelay: PublishRelay<Void> = PublishRelay()
   
+  private let rxStockItemDeleteRelay: PublishRelay<IndexPath> = PublishRelay()
+  
+  private let rxStockItemDidEditRelay: PublishRelay<IndexPath> = PublishRelay()
+  
   private let rxCombinedTextDidChangedRelay: PublishRelay<(title: String, content: String)> = PublishRelay()
   
   // MARK: Properties
@@ -395,7 +399,21 @@ extension CreateNoteViewController {
   }
   
   private func deleteCellAction(at indexPath: IndexPath) -> UIContextualAction {
-    let action = UIContextualAction(style: .destructive, title: "삭제") { _, _, completionHandler in
+    let action = UIContextualAction(style: .destructive, title: "삭제") { [weak self] _, _, completionHandler in
+      
+      let alertController = UIAlertController(title: nil, message: "종목을 삭제하시겠습니까?", preferredStyle: .alert)
+      
+      let ok = UIAlertAction(title: "확인", style: .destructive, handler: { [weak self] _ in
+        self?.rxStockItemDeleteRelay.accept(indexPath)
+      })
+      
+      let cancel = UIAlertAction(title: "취소", style: .default, handler: nil)
+      
+      alertController.addAction(cancel)
+      alertController.addAction(ok)
+      
+      self?.present(alertController, animated: true, completion: nil)
+      
       completionHandler(true)
     }
     
@@ -403,7 +421,8 @@ extension CreateNoteViewController {
   }
   
   private func editCellAction(at indexPath: IndexPath) -> UIContextualAction {
-    let action = UIContextualAction(style: .normal, title: "수정") { _, _, completionHandler in
+    let action = UIContextualAction(style: .normal, title: "수정") { [weak self] _, _, completionHandler in
+      self?.rxStockItemDidEditRelay.accept(indexPath)
       completionHandler(true)
     }
     

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
@@ -413,7 +413,7 @@ extension CreateNoteViewController {
       
       let alertController = UIAlertController(title: nil, message: "종목을 삭제하시겠습니까?", preferredStyle: .alert)
       
-      let ok = UIAlertAction(title: "확인", style: .destructive, handler: { [weak self] _ in
+      let ok = UIAlertAction(title: "확인", style: .destructive, handler: { _ in
         self?.rxStockItemDeleteRelay.accept(indexPath)
       })
       

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -54,7 +54,7 @@ final class CreateNoteViewReactor: Reactor {
     case fetchStockSection(NoteSectionItem)
     case fetchLinkSection(NoteSectionItem)
     case shouldRegisterButtonEnabeld(Bool)
-    case stockItemDidDeleted(IndexPath)
+    case stockItemDidDeleted(Int)
   }
 
   struct State: Then {
@@ -111,8 +111,8 @@ final class CreateNoteViewReactor: Reactor {
         return self.registerButtonDidTapped()
     case .stckerDidPicked(let sticker):
         return self.registNoteAndDismissView(sticker)
-    case .stockItemDidDeleted(let index):
-        return self.stockItemDidDeleted(index)
+    case .stockItemDidDeleted(let indexPath):
+        return self.stockItemDidDeleted(indexPath.row)
     case .showStockItemEditView(let index):
         return self.showStockItemEditView(index)
     case .stockItemDidUpdated(let stock):
@@ -145,8 +145,8 @@ final class CreateNoteViewReactor: Reactor {
       newState.sections[NoteSection.Identity.link.rawValue].items.append(sectionItem)
     case .shouldRegisterButtonEnabeld(let enabled):
       newState.shouldReigsterButtonEnabled = enabled
-    case .stockItemDidDeleted(let index):
-      newState.sections[NoteSection.Identity.stock.rawValue].items.remove(at: index.row)
+    case .stockItemDidDeleted(let row):
+      newState.sections[NoteSection.Identity.stock.rawValue].items.remove(at: row)
     }
 
     return newState
@@ -340,11 +340,11 @@ extension CreateNoteViewReactor {
 // MARK: - StockItem Edit & Delete
 
 extension CreateNoteViewReactor {
-  private func stockItemDidDeleted(_ index: IndexPath) -> Observable<Mutation> {
+  private func stockItemDidDeleted(_ row: Int) -> Observable<Mutation> {
     
-    self.addNoteDTO.stocks.remove(at: index.row)
+    self.addNoteDTO.stocks.remove(at: row)
 
-    return .just(.stockItemDidDeleted(index))
+    return .just(.stockItemDidDeleted(row))
   }
   
   private func showStockItemEditView(_ index: IndexPath) -> Observable<Mutation> {

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -364,7 +364,7 @@ extension CreateNoteViewReactor {
             name: stockItem.name,
             completion: self.stockItemEditCompletionRelay
           ),
-          isEditable: true
+          editMode: .modify
         ),
         using: .modal,
         animated: true,

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -42,6 +42,7 @@ final class CreateNoteViewReactor: Reactor {
     case linkButtonDidTapped
     case registerButtonDidTapped
     case stckerDidPicked(Sticker)
+    case stockItemDidDeleted(IndexPath)
   }
 
   enum Mutation {
@@ -51,6 +52,7 @@ final class CreateNoteViewReactor: Reactor {
     case fetchStockSection(NoteSectionItem)
     case fetchLinkSection(NoteSectionItem)
     case shouldRegisterButtonEnabeld(Bool)
+    case stockItemDidDeleted(IndexPath)
   }
 
   struct State: Then {
@@ -103,6 +105,8 @@ final class CreateNoteViewReactor: Reactor {
         return self.registerButtonDidTapped()
     case .stckerDidPicked(let sticker):
         return self.registNoteAndDismissView(sticker)
+    case .stockItemDidDeleted(let index):
+        return self.stockItemDidDeleted(index)
     case .dismissView:
         return dismissView()
     default:
@@ -131,6 +135,8 @@ final class CreateNoteViewReactor: Reactor {
       newState.sections[NoteSection.Identity.link.rawValue].items.append(sectionItem)
     case .shouldRegisterButtonEnabeld(let enabled):
       newState.shouldReigsterButtonEnabled = enabled
+    case .stockItemDidDeleted(let index):
+      newState.sections[NoteSection.Identity.stock.rawValue].items.remove(at: index.row)
     }
 
     return newState
@@ -318,6 +324,14 @@ extension CreateNoteViewReactor {
   }
 }
 
+extension CreateNoteViewReactor {
+  private func stockItemDidDeleted(_ index: IndexPath) -> Observable<Mutation> {
+    
+    self.addNoteDTO.stocks.remove(at: index.row)
+
+    return .just(.stockItemDidDeleted(index))
+  }
+}
 typealias CreateNoteSectionType = (AppAuthorizationType, AppCoordinatorType) -> [NoteSection]
 
 let createDiarySectionFactory: CreateNoteSectionType = { authorization, coordinator -> [NoteSection] in


### PR DESCRIPTION
### 수정내역 (필수)
- 변동률 입력 화면에서 isEditable 프로퍼티를 추가하고, 생성자에 파라미터로 추가했어요.
- ConfigureUI 메소드에서는 isEidtable 값에 따라 추가/수정 버튼의 타이틀을 변경해줘요.
- Scene에서 변동률 입력 케이스에 isEditable을 전달할 수 있도록 연관값을 추가했어요.
- AppFactory에서 변동률 입력케이스에 isEditable에 따라 modalPresentationStyle을 변경해줘요.
- 노트 등록 ViewController에서 노트 수정과 삭제 이벤트를 전달할 수 있는 Relay를 선언했어요.
- 노트 등록 화면 Reactor에서 변동률 수정 화면을 호출 할 수 있는 로직을 추가하고, completionRelay를 바인딩했어요.
- 변동률 입력화면에서 전달받은 NoteStockItem으로 해당 IndexPath의 SectionItem을 변경해줘요.
- 노트 StockReactor에서 현재 State를 변경할 수 있는 Action과 Mutation을 정의했어요.
- 노트 등록 화면 Reactor에서 삭제 기능을 구현했어요.

### 스크린샷 (선택사항)
|**종목 삭제**|
|--------------------|
|<img src="https://user-images.githubusercontent.com/19662529/148947075-6d4741ed-e06e-4970-a163-88252147376f.gif" width=320>|

|**종목 수정**|
|--------------------|
|<img src="https://user-images.githubusercontent.com/19662529/148947082-8b41facc-fdeb-4b10-bf91-1f1c2bc68598.gif" width=320>|

