### PR TITLE
[Domain] 전달된 노트 데이터로 노트 입력 화면을 그려줘요.

### DIFF
--- a/Tooda/Sources/Core/AppFactory.swift
+++ b/Tooda/Sources/Core/AppFactory.swift
@@ -47,7 +47,10 @@ final class AppFactory: AppFactoryType {
           authorization: self.dependency.appInject.resolve(AppAuthorizationType.self),
           linkPreviewService:
             self.dependency.appInject.resolve(LinkPreViewServiceType.self),
-          createDiarySectionFactory: createDiarySectionFactory)
+          createDiarySectionFactory: createDiarySectionFactory,
+          modifiableNoteSectionFactory: nil
+        ),
+        modifiableNote: nil
       )
         
       let viewController = CreateNoteViewController(dateString: today, reactor: reactor)

--- a/Tooda/Sources/Core/AppFactory.swift
+++ b/Tooda/Sources/Core/AppFactory.swift
@@ -57,6 +57,25 @@ final class AppFactory: AppFactoryType {
       let navigationController = UINavigationController(rootViewController: viewController)
       navigationController.modalPresentationStyle = .overFullScreen
       return navigationController
+        
+    case .modifyNote(let dateString, let note):
+        let reactor = CreateNoteViewReactor(
+          dependency: .init(
+            service: self.dependency.appInject.resolve(NetworkingProtocol.self),
+            coordinator: self.dependency.appInject.resolve(AppCoordinatorType.self),
+            authorization: self.dependency.appInject.resolve(AppAuthorizationType.self),
+            linkPreviewService:
+              self.dependency.appInject.resolve(LinkPreViewServiceType.self),
+            createDiarySectionFactory: nil,
+            modifiableNoteSectionFactory: modifiableNoteSectionFactory
+          ),
+          modifiableNote: note
+        )
+        
+        let viewController = CreateNoteViewController(dateString: dateString, reactor: reactor)
+        let navigationController = UINavigationController(rootViewController: viewController)
+        navigationController.modalPresentationStyle = .overFullScreen
+        return navigationController
 
     case .login:
       let reactor = LoginReactor(

--- a/Tooda/Sources/Core/Coordinator/AppCoordinator.swift
+++ b/Tooda/Sources/Core/Coordinator/AppCoordinator.swift
@@ -113,7 +113,7 @@ final class AppCoordinator: AppCoordinatorType {
           return $0 is LoginViewController
         case .home:
           return $0 is HomeViewController
-        case .createNote:
+        case .createNote, .modifyNote:
           return $0 is CreateNoteViewController
         case .settings:
           return $0 is SettingsViewController

--- a/Tooda/Sources/Core/Coordinator/Scene.swift
+++ b/Tooda/Sources/Core/Coordinator/Scene.swift
@@ -16,6 +16,7 @@ enum Scene {
   case login
   case home
   case createNote(dateString: String)
+  case modifyNote(dateString: String, note: AddNoteDTO)
   case settings
   case addStock(completion: PublishRelay<NoteStock>)
   case search
@@ -32,6 +33,7 @@ enum Scene {
     case .login:              return "login"
     case .home:               return "home"
     case .createNote:         return "createNote"
+    case .modifyNote:         return "modifyNote"
     case .settings:           return "settings"
     case .addStock:           return "addStock"
     case .search:             return "search"

--- a/Tooda/Sources/Entities/Note/AddNoteDTO.swift
+++ b/Tooda/Sources/Entities/Note/AddNoteDTO.swift
@@ -7,7 +7,11 @@
 
 import Foundation
 
+// TODO: 등록, 수정을 동시에 다룰 수 있는 자료형으로 변경할 예정이에요.
 struct AddNoteDTO {
+  var id: String?
+  var updatedAt: String?
+  var createdAt: String?
   var title: String
   var content: String
   var stocks: [NoteStock]

--- a/Tooda/Sources/Scenes/CreateNote/Cells/NoteContentCell.swift
+++ b/Tooda/Sources/Scenes/CreateNote/Cells/NoteContentCell.swift
@@ -111,6 +111,15 @@ class NoteContentCell: BaseTableViewCell, View {
 
   func bind(reactor: Reactor) {
 
+    reactor.state
+      .map { $0.payload }
+      .compactMap { $0 }
+      .asDriver(onErrorJustReturn: .init(title: "", content: ""))
+      .drive(onNext: { [weak self] in
+        self?.titleTextField.text = $0.title
+        self?.contentTextView.text = $0.content
+      })
+      .disposed(by: self.disposeBag)
   }
 }
 

--- a/Tooda/Sources/Scenes/CreateNote/Cells/Reactors/NoteContentCellReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/Cells/Reactors/NoteContentCellReactor.swift
@@ -19,14 +19,19 @@ final class NoteContentCellReactor: Reactor {
   }
 
   struct State {
-
+    var payload: Payload?
+  }
+  
+  struct Payload {
+    var title: String
+    var content: String
   }
 
   let initialState: State
   private let uuid: String = UUID().uuidString
 
-  init() {
-    initialState = State()
+  init(payload: Payload?) {
+    initialState = State(payload: payload)
   }
 
 //	func mutate(action: Action) -> Observable<Mutation> {

--- a/Tooda/Sources/Scenes/CreateNote/Cells/Reactors/NoteImageCellReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/Cells/Reactors/NoteImageCellReactor.swift
@@ -41,9 +41,9 @@ final class NoteImageCellReactor: Reactor {
   
   private let uuid: String = UUID().uuidString
 
-  init(dependency: Dependency) {
+  init(dependency: Dependency, images: [NoteImage] = []) {
     self.dependency = dependency
-    initialState = State(sections: dependency.factory([]))
+    initialState = State(sections: dependency.factory(images))
   }
 
   func mutate(action: Action) -> Observable<Mutation> {

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
@@ -14,6 +14,7 @@ import RxDataSources
 import ReactorKit
 import SnapKit
 
+// TODO: 노트 등록이 아닌 입력과 관련된 이름으로 변경해요.
 class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
   typealias Reactor = CreateNoteViewReactor
 

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -11,6 +11,7 @@ import ReactorKit
 import Then
 import RxRelay
 
+// TODO: 노트 등록이 아닌 입력과 관련된 이름으로 변경해요.
 final class CreateNoteViewReactor: Reactor {
   
   enum ViewPresentType {

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -407,8 +407,8 @@ let createDiarySectionFactory: CreateNoteSectionType = { authorization, coordina
     NoteSection(identity: .link, items: []),
     NoteSection(identity: .image, items: [])
   ]
-
-  let contentReactor: NoteContentCellReactor = NoteContentCellReactor()
+  
+  let contentReactor: NoteContentCellReactor = NoteContentCellReactor(payload: .init(title: "", content: ""))
   let contentSectionItem: NoteSectionItem = NoteSectionItem.content(contentReactor)
   
   let addStockReactor: EmptyNoteStockCellReactor = EmptyNoteStockCellReactor()


### PR DESCRIPTION
### 수정내역 (필수)
- AddNoteDTO에 노트 수정과 관련된 프로퍼티를 추가했어요. **id, updatedAt, createdAt**
- ModifiableNoteSectionType을 추가했어요. 전달받은 AddNoteDTO로 NoteSection을 그려줘요.
- `NoteContentCellReactor`에 Payload를 추가하고 State에 프로퍼티로 추가했어요. 그리고 Reactor에 Binding 코드를 추가했어요.
- `NoteImageCellReactor` 생성자에 images를 추가했어요.
- 노트 등록 화면의 Dependency에 modifiableNoteSectionFactory 프로퍼티를 추가하고 modifableNote를 파라미터로 추가했어요.
- 노트 등록 Reactor의 makeSection 로직을 변경했어요. Dependency의 sectionFactory의 유무에 따라서 다른 section을 그려줘요.
- Scene에 modify case를 추가했어요.
- AppFactory에서 createNote와 modifyNote case를 정의했어요.

### 스크린샷 (선택사항)
![ezgif com-gif-maker (13)](https://user-images.githubusercontent.com/19662529/149664374-859405ed-a5e7-4222-ac82-e51874c53c21.gif)

