### PR TITLE
[Domain] 노트 상세 화면에 tableView을 추가하고 DetailSection을 정의했어요.

### DIFF
--- a/Tooda/Sources/Scenes/NoteDetail/NoteDetailViewController.swift
+++ b/Tooda/Sources/Scenes/NoteDetail/NoteDetailViewController.swift
@@ -14,6 +14,17 @@ import Then
 import SnapKit
 
 final class NoteDetailViewController: BaseViewController<NoteDetailReactor> {
+  
+  // MARK: UI Properties
+  
+  private let tableView = UITableView().then {
+    $0.separatorStyle = .none
+    $0.backgroundColor = .white
+    $0.estimatedRowHeight = UITableView.automaticDimension
+    $0.alwaysBounceHorizontal = false
+    
+    $0.allowsSelection = false
+  }
 
   // MARK: Initializing
 
@@ -30,11 +41,17 @@ final class NoteDetailViewController: BaseViewController<NoteDetailReactor> {
   // MARK: Configuring
 
   override func configureUI() {
-
+    super.configureUI()
+    self.view.addSubviews(tableView)
   }
 
   override func configureConstraints() {
-
+    super.configureConstraints()
+    
+    tableView.snp.makeConstraints {
+      $0.top.equalTo(self.view.safeAreaLayoutGuide)
+      $0.leading.trailing.bottom.equalToSuperview()
+    }
   }
 
 

--- a/Tooda/Sources/Scenes/NoteDetail/Section/NoteDetailSection.swift
+++ b/Tooda/Sources/Scenes/NoteDetail/Section/NoteDetailSection.swift
@@ -10,7 +10,6 @@ import RxDataSources
 struct NoteDetailSection {
   enum Identity: Int {
     case header
-    case content
     case stock
     case link
     case image

--- a/Tooda/Sources/Scenes/NoteDetail/Section/NoteDetailSection.swift
+++ b/Tooda/Sources/Scenes/NoteDetail/Section/NoteDetailSection.swift
@@ -1,0 +1,36 @@
+//
+//  NoteDetailSection.swift
+//  Tooda
+//
+//  Created by Lyine on 2022/01/19.
+//
+
+import RxDataSources
+
+struct NoteDetailSection {
+  enum Identity: Int {
+    case header
+    case content
+    case stock
+    case link
+    case image
+  }
+  let identity: Identity
+  var items: [NoteDetailSectionItem]
+}
+
+extension NoteDetailSection: SectionModelType {
+  init(original: NoteDetailSection, items: [NoteDetailSectionItem]) {
+    self = .init(identity: original.identity, items: items)
+  }
+}
+
+enum NoteDetailSectionItem {
+  case sticker(Sticker)
+  case title(String)
+  case updateDate(String)
+  case content(String)
+  case stock(NoteStockCellReactor)
+  case image(String)
+  case link(NoteLinkCellReactor)
+}


### PR DESCRIPTION
### 수정내역 (필수)
- 노트 상세 화면에 tableView를 추가하고 UI를 설정했어요.
- 노트 상세 화면 tableVieew DataSource로 사용될 DetailSection과 DetailSectionItem을 정의했어요.
