### PR TITLE
[UI] 노트 상세페이지와 관련된 셀들의 기본 UI 레이아웃을 구현했어요

### DIFF
--- a/Tooda/Sources/Scenes/NoteDetail/Cells/NoteDetailTextContentCell.swift
+++ b/Tooda/Sources/Scenes/NoteDetail/Cells/NoteDetailTextContentCell.swift
@@ -10,8 +10,12 @@ import UIKit
 import SnapKit
 
 final class NoteDetailTextContentCell: UITableViewCell {
+  
+  // MARK: - UI Components
 
   private let descriptionLabel = UILabel()
+  
+  // MARK: - Con(De)structor
   
   override init(
     style: UITableViewCell.CellStyle,
@@ -23,10 +27,7 @@ final class NoteDetailTextContentCell: UITableViewCell {
     )
   }
   
-  func configure() {
-    
-  }
-
+  // MARK: - Overridden: ParentClass
   
   override func configureUI() {
     super.configureUI()
@@ -40,5 +41,11 @@ final class NoteDetailTextContentCell: UITableViewCell {
       $0.top.bottom.equalToSuperview().inset(15)
       $0.leading.trailing.equalToSuperview().inset(20)
     }
+  }
+  
+  // MARK: - Internal methods
+  
+  func configure() {
+    
   }
 }

--- a/Tooda/Sources/Scenes/NoteDetail/Cells/NoteDetailTextContentCell.swift
+++ b/Tooda/Sources/Scenes/NoteDetail/Cells/NoteDetailTextContentCell.swift
@@ -1,0 +1,44 @@
+//
+//  NoteDetailTextContentCell.swift
+//  Tooda
+//
+//  Created by 황재욱 on 2022/01/22.
+//
+
+import UIKit
+
+import SnapKit
+
+final class NoteDetailTextContentCell: UITableViewCell {
+
+  private let descriptionLabel = UILabel()
+  
+  override init(
+    style: UITableViewCell.CellStyle,
+    reuseIdentifier: String?
+  ) {
+    super.init(
+      style: style,
+      reuseIdentifier: reuseIdentifier
+    )
+  }
+  
+  func configure() {
+    
+  }
+
+  
+  override func configureUI() {
+    super.configureUI()
+    contentView.addSubview(descriptionLabel)
+  }
+  
+  override func setupConstraints() {
+    super.setupConstraints()
+    
+    descriptionLabel.snp.makeConstraints {
+      $0.top.bottom.equalToSuperview().inset(15)
+      $0.leading.trailing.equalToSuperview().inset(20)
+    }
+  }
+}

--- a/Tooda/Sources/Scenes/NoteDetail/Cells/NoteDetailTitleCell.swift
+++ b/Tooda/Sources/Scenes/NoteDetail/Cells/NoteDetailTitleCell.swift
@@ -8,10 +8,14 @@
 import UIKit
 
 final class NoteDetailTitleCell: UITableViewCell {
+  
+  // MARK: - UI Components
 
   private let titleLabel = UILabel()
   
   private let dateLabel = UILabel()
+  
+  // MARK: - Con(De)structor
   
   override init(
     style: UITableViewCell.CellStyle,
@@ -23,10 +27,7 @@ final class NoteDetailTitleCell: UITableViewCell {
     )
   }
   
-  func configure() {
-    
-  }
-  
+  // MARK: - Overridden: ParentClass
   
   override func configureUI() {
     super.configureUI()
@@ -47,5 +48,12 @@ final class NoteDetailTitleCell: UITableViewCell {
       $0.top.equalTo(titleLabel.snp.bottom).offset(5)
       $0.leading.trailing.equalToSuperview().inset(19)
     }
+  }
+  
+  
+  // MARK: - Internal methods
+  
+  func configure() {
+    
   }
 }

--- a/Tooda/Sources/Scenes/NoteDetail/Cells/NoteDetailTitleCell.swift
+++ b/Tooda/Sources/Scenes/NoteDetail/Cells/NoteDetailTitleCell.swift
@@ -1,0 +1,40 @@
+//
+//  NoteDetailTitleCell.swift
+//  Tooda
+//
+//  Created by 황재욱 on 2022/01/22.
+//
+
+import UIKit
+
+final class NoteDetailTitleCell: UITableViewCell {
+
+  private let titleLabel = UILabel()
+  
+  private let dateLabel = UILabel()
+  
+  override init(
+    style: UITableViewCell.CellStyle,
+    reuseIdentifier: String?
+  ) {
+    super.init(
+      style: style,
+      reuseIdentifier: reuseIdentifier
+    )
+  }
+  
+  func configure() {
+    
+  }
+  
+  
+  override func configureUI() {
+    super.configureUI()
+    
+  }
+  
+  override func setupConstraints() {
+    super.setupConstraints()
+    
+  }
+}

--- a/Tooda/Sources/Scenes/NoteDetail/Cells/NoteDetailTitleCell.swift
+++ b/Tooda/Sources/Scenes/NoteDetail/Cells/NoteDetailTitleCell.swift
@@ -30,11 +30,22 @@ final class NoteDetailTitleCell: UITableViewCell {
   
   override func configureUI() {
     super.configureUI()
-    
+    contentView.addSubviews(
+      titleLabel,
+      dateLabel
+    )
   }
   
   override func setupConstraints() {
     super.setupConstraints()
+    titleLabel.snp.makeConstraints {
+      $0.top.equalToSuperview().inset(1)
+      $0.leading.trailing.equalToSuperview().inset(19)
+    }
     
+    dateLabel.snp.makeConstraints {
+      $0.top.equalTo(titleLabel.snp.bottom).offset(5)
+      $0.leading.trailing.equalToSuperview().inset(19)
+    }
   }
 }

--- a/Tooda/Sources/Scenes/NoteDetail/Cells/NoteStickerCell.swift
+++ b/Tooda/Sources/Scenes/NoteDetail/Cells/NoteStickerCell.swift
@@ -41,6 +41,15 @@ final class NoteStickerCell: BaseTableViewCell {
   override func setupConstraints() {
     super.setupConstraints()
     
-    stickerImageView
+    stickerImageView.snp.makeConstraints {
+      $0.leading.equalToSuperview().inset(21)
+      $0.centerY.equalToSuperview()
+    }
+    
+    titleLabel.snp.makeConstraints {
+      $0.leading.equalTo(stickerImageView.snp.trailing).offset(8)
+      $0.centerY.equalToSuperview()
+      $0.trailing.equalToSuperview().inset(20)
+    }
   }
 }

--- a/Tooda/Sources/Scenes/NoteDetail/Cells/NoteStickerCell.swift
+++ b/Tooda/Sources/Scenes/NoteDetail/Cells/NoteStickerCell.swift
@@ -9,11 +9,15 @@ import UIKit
 
 final class NoteStickerCell: BaseTableViewCell {
   
+  // MARK: - UI Components
+  
   private let stickerImageView = UIImageView().then {
     $0.contentMode = .scaleAspectFit
   }
   
   private let titleLabel = UILabel()
+  
+  // MARK: - Con(De)structor
 
   override init(
     style: UITableViewCell.CellStyle,
@@ -25,9 +29,7 @@ final class NoteStickerCell: BaseTableViewCell {
     )
   }
   
-  func configure() {
-    
-  }
+  // MARK: - Overridden: ParentClass
   
   override func configureUI() {
     super.configureUI()

--- a/Tooda/Sources/Scenes/NoteDetail/Cells/NoteStickerCell.swift
+++ b/Tooda/Sources/Scenes/NoteDetail/Cells/NoteStickerCell.swift
@@ -1,0 +1,46 @@
+//
+//  NoteStickerCell.swift
+//  Tooda
+//
+//  Created by 황재욱 on 2022/01/22.
+//
+
+import UIKit
+
+final class NoteStickerCell: BaseTableViewCell {
+  
+  private let stickerImageView = UIImageView().then {
+    $0.contentMode = .scaleAspectFit
+  }
+  
+  private let titleLabel = UILabel()
+
+  override init(
+    style: UITableViewCell.CellStyle,
+    reuseIdentifier: String?
+  ) {
+    super.init(
+      style: style,
+      reuseIdentifier: reuseIdentifier
+    )
+  }
+  
+  func configure() {
+    
+  }
+  
+  override func configureUI() {
+    super.configureUI()
+    contentView.addSubviews(
+      stickerImageView,
+      titleLabel
+    )
+    
+  }
+  
+  override func setupConstraints() {
+    super.setupConstraints()
+    
+    stickerImageView
+  }
+}


### PR DESCRIPTION
### 수정내역 (필수)
- 노트 상세페이지와 관련된 셀(NoteStickerCell, NoteDetailTitleCell, NoteDetailTextContentCell)을 추가
- 관련 셀의 UI 레이아웃 구현
