### PR TITLE
[Domain] 노트 입력 화면에서 수정 버튼을 추가했어요.

### DIFF
--- a/Tooda/Sources/Core/AppFactory.swift
+++ b/Tooda/Sources/Core/AppFactory.swift
@@ -53,7 +53,7 @@ final class AppFactory: AppFactoryType {
         modifiableNote: nil
       )
         
-      let viewController = CreateNoteViewController(dateString: today, reactor: reactor)
+      let viewController = CreateNoteViewController(dateString: today, reactor: reactor, mode: .add)
       let navigationController = UINavigationController(rootViewController: viewController)
       navigationController.modalPresentationStyle = .overFullScreen
       return navigationController
@@ -72,7 +72,7 @@ final class AppFactory: AppFactoryType {
           modifiableNote: note
         )
         
-        let viewController = CreateNoteViewController(dateString: dateString, reactor: reactor)
+        let viewController = CreateNoteViewController(dateString: dateString, reactor: reactor, mode: .update)
         let navigationController = UINavigationController(rootViewController: viewController)
         navigationController.modalPresentationStyle = .overFullScreen
         return navigationController

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
@@ -256,6 +256,11 @@ class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
       .bind(to: reactor.action)
       .disposed(by: self.disposeBag)
     
+    self.updateButton.rx.tap
+      .map { _ in Reactor.Action.updateButtonDidTapped }
+      .bind(to: reactor.action)
+      .disposed(by: self.disposeBag)
+    
     imageItemCellDidTapRelay
       .map { Reactor.Action.didSelectedImageItem($0) }
       .bind(to: reactor.action)

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
@@ -117,6 +117,15 @@ class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
     $0.setButtonTitle(with: "수정", style: TextStyle.body2Bold(color: UIColor.white))
     $0.configureShadow(color: .clear, x: 0, y: 0, blur: 0, spread: 0)
   }
+  
+  private var rightBarButton: UIBarButtonItem {
+    switch self.editMode {
+      case .add:
+        return UIBarButtonItem(customView: self.registerButton)
+      case .update:
+        return UIBarButtonItem(customView: self.updateButton)
+    }
+  }
 
   private lazy var tableView = UITableView().then {
     $0.separatorStyle = .none

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
@@ -112,7 +112,10 @@ class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
     $0.configureShadow(color: .clear, x: 0, y: 0, blur: 0, spread: 0)
   }
   
-  private lazy var rightBarButton = UIBarButtonItem(customView: self.registerButton)
+  private let updateButton = BaseButton(width: 53, height: 28).then {
+    $0.setButtonTitle(with: "수정", style: TextStyle.body2Bold(color: UIColor.white))
+    $0.configureShadow(color: .clear, x: 0, y: 0, blur: 0, spread: 0)
+  }
 
   private lazy var tableView = UITableView().then {
     $0.separatorStyle = .none

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
@@ -20,6 +20,11 @@ class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
 
   typealias Section = RxTableViewSectionedAnimatedDataSource<NoteSection>
   
+  enum EditMode {
+    case add
+    case update
+  }
+  
   private enum Metric {
     static let linkButtonSize: CGFloat = 20.0
   }

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
@@ -96,6 +96,7 @@ class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
   
   private let dateString: String
 
+  private var editMode: EditMode
   // MARK: UI-Properties
   
   private lazy var titleLabel = UILabel().then {
@@ -158,12 +159,13 @@ class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
     fatalError("init(coder:) has not been implemented")
   }
 
-  init(dateString: String, reactor: Reactor) {
+  init(dateString: String, reactor: Reactor, mode: EditMode) {
     defer {
       self.reactor = reactor
     }
     
     self.dateString = dateString
+    self.editMode = mode
     super.init()
   }
   

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -43,6 +43,7 @@ final class CreateNoteViewReactor: Reactor {
     case makeTitleAndContent(title: String, content: String)
     case linkButtonDidTapped
     case registerButtonDidTapped
+    case updateButtonDidTapped
     case stckerDidPicked(Sticker)
     case stockItemDidDeleted(IndexPath)
     case showStockItemEditView(IndexPath)
@@ -115,6 +116,8 @@ final class CreateNoteViewReactor: Reactor {
         return self.linkButtonDidTapped()
     case .registerButtonDidTapped:
         return self.registerButtonDidTapped()
+    case .updateButtonDidTapped:
+        return self.updateButtonDidTapped()
     case .stckerDidPicked(let sticker):
         return self.registNoteAndDismissView(sticker)
     case .stockItemDidDeleted(let indexPath):
@@ -355,6 +358,16 @@ self.dependency.coordinator.transition(
           return .empty()
         }
       }
+  }
+}
+
+// MARK: - Update Button Did Tap
+
+extension CreateNoteViewReactor {
+  
+  // TODO: 노트 한줄평 PopUp을 연결해요.
+  private func updateButtonDidTapped() -> Observable<Mutation> {
+    return .empty()
   }
 }
 


### PR DESCRIPTION
### 수정내역 (필수)
- 노트 입력 화면에서 노트 등록과 수정을 구분하기 위한 EditMode Enum을 정의했어요.
- 노트 입력 화면에서 EditMode 멤버변수를 정의하고 생성자에 코드를 추가했어요.
- AppFactory에서 EditMode를 다르게 넣어줘요.
- 노트 입력 화면에서 rightBarButton을 computedProperty로 변경하고 editMode에 따라 다른 customView를 반환하도록 변경했어요.
- 수정 버튼 탭에 대한 이벤트를 연결했어요.


### Todo:
- [ ] : 노트 수정 버튼을 누르면 노트 수정 API를 호출해요.