### PR TITLE
[Core] 노트 리스트 화면에 노트 상세 화면을 연결하고 노트 상세 initial data load 로직을 구현했어요

### DIFF
--- a/Tooda/Sources/Core/AppFactory.swift
+++ b/Tooda/Sources/Core/AppFactory.swift
@@ -181,10 +181,12 @@ final class AppFactory: AppFactoryType {
 
       return SearchResultViewController(reactor: reactor)
 
-    case .noteDetail:
+    case let .noteDetail(payload):
       let reactor = NoteDetailReactor(
         dependency: .init(
-          coordinator: self.dependency.appInject.resolve(AppCoordinatorType.self)
+          service: self.dependency.appInject.resolve(NetworkingProtocol.self),
+          coordinator: self.dependency.appInject.resolve(AppCoordinatorType.self),
+          payload: payload
         )
       )
 

--- a/Tooda/Sources/Core/Coordinator/Scene.swift
+++ b/Tooda/Sources/Core/Coordinator/Scene.swift
@@ -25,7 +25,7 @@ enum Scene {
   case stockRateInput(payload: StockRateInputReactor.Payload, editMode: StockRateInputViewController.EditMode = .input)
   case popUp(type: PopUpReactor.PopUpType)
   case searchResult
-  case noteDetail
+  case noteDetail(payload: NoteDetailReactor.Payload)
   case inAppBrowser(url: URL)
   
   var screenName: String {

--- a/Tooda/Sources/Networking/API/NoteAPI.swift
+++ b/Tooda/Sources/Networking/API/NoteAPI.swift
@@ -17,7 +17,7 @@ enum NoteAPI {
   case delete(id: String)
   case addImage(data: Data)
   case update(dto: NoteRequestDTO)
-  case detail(id: String)
+  case detail(id: Int)
 }
 
 extension NoteAPI: BaseAPI {

--- a/Tooda/Sources/Scenes/NoteDetail/Cells/NoteStickerCell.swift
+++ b/Tooda/Sources/Scenes/NoteDetail/Cells/NoteStickerCell.swift
@@ -55,6 +55,14 @@ final class NoteStickerCell: BaseTableViewCell {
       $0.leading.equalTo(stickerImageView.snp.trailing).offset(8)
       $0.centerY.equalToSuperview()
       $0.trailing.equalToSuperview().inset(20)
+      $0.top.bottom.equalToSuperview().inset(11)
     }
+  }
+  
+  // MARK: - Internal methods
+  
+  func configure(sticker: Sticker) {
+    stickerImageView.image = sticker.image
+    titleLabel.text = sticker.optionTitle
   }
 }

--- a/Tooda/Sources/Scenes/NoteDetail/NoteDetailReactor.swift
+++ b/Tooda/Sources/Scenes/NoteDetail/NoteDetailReactor.swift
@@ -15,22 +15,23 @@ final class NoteDetailReactor: Reactor {
   // MARK: Dependency
 
   struct Dependency {
+    let service: NetworkingProtocol
     let coordinator: AppCoordinatorType
   }
-
 
   // MARK: Reactor
 
   enum Action {
+    case loadData
     case back
   }
 
   enum Mutation {
-
+    case setNoteDetailSectionModel([NoteDetailSection])
   }
 
   struct State {
-
+    var sectionModel: [NoteDetailSection]
   }
 
 
@@ -38,7 +39,7 @@ final class NoteDetailReactor: Reactor {
 
   private let dependency: Dependency
 
-  let initialState: State = State()
+  let initialState: State = State(sectionModel: [])
 
   init(dependency: Dependency) {
     self.dependency = dependency
@@ -52,6 +53,8 @@ extension NoteDetailReactor {
 
   func mutate(action: Action) -> Observable<Mutation> {
     switch action {
+    case .loadData:
+      loadDataMutation()
     case .back:
       self.dependency.coordinator.close(
         style: .pop,
@@ -60,6 +63,27 @@ extension NoteDetailReactor {
       )
       return .empty()
     }
+  }
+  
+  private func loadDataMutation() -> Observable<Mutation> {
+    return dependency.service.request(NoteAPI.detail(id: ""))
+      .map(Note.self)
+      .asObservable()
+      .flatMap { note -> Observable<Mutation> in
+        let sectionModels = [
+          NoteDetailSection(
+            identity: .header,
+            items: [
+              .sticker(note.sticker ?? Sticker.wow),
+              .title(note.title, note.updatedAt),
+              .content(note.content)
+            ]
+          )
+        ]
+        return Observable<Mutation>.just(
+          Mutation.setNoteDetailSectionModel(sectionModels)
+        )
+      }
   }
 }
 
@@ -71,6 +95,11 @@ extension NoteDetailReactor {
   func reduce(state: State, mutation: Mutation) -> State {
     var newState = state
 
+    switch mutation {
+    case let .setNoteDetailSectionModel(sectionModel):
+      newState.sectionModel = sectionModel
+    }
+    
     return newState
   }
 }

--- a/Tooda/Sources/Scenes/NoteDetail/Section/NoteDetailSection.swift
+++ b/Tooda/Sources/Scenes/NoteDetail/Section/NoteDetailSection.swift
@@ -26,8 +26,7 @@ extension NoteDetailSection: SectionModelType {
 
 enum NoteDetailSectionItem {
   case sticker(Sticker)
-  case title(String)
-  case updateDate(String)
+  case title(String, String?)
   case content(String)
   case stock(NoteStockCellReactor)
   case image(String)

--- a/Tooda/Sources/Scenes/NoteList/NoteListReactor.swift
+++ b/Tooda/Sources/Scenes/NoteList/NoteListReactor.swift
@@ -33,6 +33,7 @@ final class NoteListReactor: Reactor {
     case dismiss
     case pagnationLoad(willDisplayIndex: Int)
     case addNoteButtonTap
+    case noteCellTap(index: Int)
   }
   
   enum Mutation {
@@ -92,6 +93,8 @@ extension NoteListReactor {
       return pagnationLoadMutation(nextDisplayIndex: willDisplayIndex)
     case .addNoteButtonTap:
       return routeToCreateNote()
+    case let .noteCellTap(selectedIndex):
+      return routeToNoteDetail(selectedIndex: selectedIndex)
     }
   }
   
@@ -108,6 +111,17 @@ extension NoteListReactor {
     dependency.coordinator.transition(
       to: .createNote(dateString: "\(currentState.dateInfo.year).\(currentState.dateInfo.month)"),
       using: .modal,
+      animated: true,
+      completion: nil
+    )
+    return Observable<Mutation>.empty()
+  }
+  
+  private func routeToNoteDetail(selectedIndex: Int) -> Observable<Mutation> {
+    guard let noteID = currentState.noteListModel.first?.items[safe: selectedIndex]?.id else { return Observable<Mutation>.empty() }
+    dependency.coordinator.transition(
+      to: .noteDetail(payload: NoteDetailReactor.Payload(id: noteID)),
+      using: .push,
       animated: true,
       completion: nil
     )

--- a/Tooda/Sources/Scenes/NoteList/NoteListViewController.swift
+++ b/Tooda/Sources/Scenes/NoteList/NoteListViewController.swift
@@ -144,6 +144,11 @@ final class NoteListViewController: BaseViewController<NoteListReactor> {
     tableView.rx.setDelegate(self)
       .disposed(by: disposeBag)
     
+    tableView.rx.itemSelected
+      .map { NoteListReactor.Action.noteCellTap(index: $0.item) }
+      .bind(to: reactor.action)
+      .disposed(by: self.disposeBag)
+    
     reactor.state
       .map { $0.dateInfo }
       .asDriver(onErrorJustReturn: (year: Date().year, month: Date().month))


### PR DESCRIPTION
### 수정내역 (필수)
- 노트 상세 첫 데이터 로딩 action 추가 및 테이블뷰 state binding
- 노트 리스트 화면 셀 선택 시 화면 라우팅 로직 추가
- 노트 상세 id 전달을 위한 Payload 추가

### 스크린샷 (선택사항)
- 노트 상세 data 잘 오는 것 확인

<img width="536" alt="스크린샷 2022-01-25 오후 5 56 01" src="https://user-images.githubusercontent.com/31857308/150945608-fae86536-35ac-4cfa-a27a-8fa34f622646.png">


