### PR TITLE
[UI] 노트 디테일 화면 header 부분 타이틀, 내용, 스티커를 볼 수 있어요

### DIFF
--- a/Tooda/Sources/Scenes/NoteDetail/Cells/NoteDetailTextContentCell.swift
+++ b/Tooda/Sources/Scenes/NoteDetail/Cells/NoteDetailTextContentCell.swift
@@ -11,6 +11,10 @@ import SnapKit
 
 final class NoteDetailTextContentCell: BaseTableViewCell {
   
+  enum Font {
+    static let content = TextStyle.body(color: .gray1)
+  }
+  
   // MARK: - UI Components
 
   private let descriptionLabel = UILabel()
@@ -45,5 +49,11 @@ final class NoteDetailTextContentCell: BaseTableViewCell {
       $0.top.bottom.equalToSuperview().inset(15)
       $0.leading.trailing.equalToSuperview().inset(20)
     }
+  }
+  
+  // MARK: - Internal methods
+  
+  func configure(content: String) {
+    descriptionLabel.attributedText = content.styled(with: Font.content)
   }
 }

--- a/Tooda/Sources/Scenes/NoteDetail/Cells/NoteDetailTitleCell.swift
+++ b/Tooda/Sources/Scenes/NoteDetail/Cells/NoteDetailTitleCell.swift
@@ -9,6 +9,11 @@ import UIKit
 
 final class NoteDetailTitleCell: BaseTableViewCell {
   
+  enum Font {
+    static let title = TextStyle.titleBold(color: .gray1)
+    static let dateInfo = TextStyle.captionBold(color: .gray1)
+  }
+  
   // MARK: - UI Components
 
   private let titleLabel = UILabel()
@@ -51,6 +56,19 @@ final class NoteDetailTitleCell: BaseTableViewCell {
     dateLabel.snp.makeConstraints {
       $0.top.equalTo(titleLabel.snp.bottom).offset(5)
       $0.leading.trailing.equalToSuperview().inset(19)
+      $0.bottom.equalToSuperview().inset(15)
+    }
+  }
+  
+  // MARK: - Internal methods
+  
+  func configure(title: String?, date: String?) {
+    if let title = title {
+      titleLabel.attributedText = title.styled(with: Font.title)
+    }
+    
+    if let dateString = date {
+      dateLabel.attributedText = dateString.styled(with: Font.dateInfo)
     }
   }
 }

--- a/Tooda/Sources/Scenes/NoteDetail/Cells/NoteStickerCell.swift
+++ b/Tooda/Sources/Scenes/NoteDetail/Cells/NoteStickerCell.swift
@@ -9,6 +9,10 @@ import UIKit
 
 final class NoteStickerCell: BaseTableViewCell {
   
+  enum Font {
+    static let title = TextStyle.bodyBold(color: .gray1)
+  }
+  
   // MARK: - UI Components
   
   private let stickerImageView = UIImageView().then {
@@ -47,7 +51,8 @@ final class NoteStickerCell: BaseTableViewCell {
     super.setupConstraints()
     
     stickerImageView.snp.makeConstraints {
-      $0.leading.equalToSuperview().inset(21)
+      $0.leading.equalToSuperview().inset(19)
+      $0.width.height.equalTo(24)
       $0.centerY.equalToSuperview()
     }
     
@@ -55,14 +60,15 @@ final class NoteStickerCell: BaseTableViewCell {
       $0.leading.equalTo(stickerImageView.snp.trailing).offset(8)
       $0.centerY.equalToSuperview()
       $0.trailing.equalToSuperview().inset(20)
-      $0.top.bottom.equalToSuperview().inset(11)
+      $0.top.bottom.equalToSuperview().inset(20)
     }
   }
   
   // MARK: - Internal methods
   
   func configure(sticker: Sticker) {
+    super.configure()
     stickerImageView.image = sticker.image
-    titleLabel.text = sticker.optionTitle
+    titleLabel.attributedText = sticker.optionTitle.styled(with: Font.title)
   }
 }

--- a/Tooda/Sources/Scenes/NoteDetail/NoteDetailReactor.swift
+++ b/Tooda/Sources/Scenes/NoteDetail/NoteDetailReactor.swift
@@ -87,7 +87,7 @@ extension NoteDetailReactor {
             identity: .header,
             items: [
               .sticker(note.sticker ?? Sticker.wow),
-              .title(note.title, note.updatedAt),
+              .title(note.title, note.updatedAt ?? note.createdAt),
               .content(note.content)
             ]
           )

--- a/Tooda/Sources/Scenes/NoteDetail/NoteDetailViewController.swift
+++ b/Tooda/Sources/Scenes/NoteDetail/NoteDetailViewController.swift
@@ -32,13 +32,15 @@ final class NoteDetailViewController: BaseViewController<NoteDetailReactor> {
       }
       
       if case let .title(title, date) = item {
-        let noteStickerCell = tableView.dequeue(NoteStickerCell.self, indexPath: indexPath)
-        return noteStickerCell
+        let noteDetailTitleCell = tableView.dequeue(NoteDetailTitleCell.self, indexPath: indexPath)
+        noteDetailTitleCell.configure(title: title, date: date)
+        return noteDetailTitleCell
       }
       
       if case let .content(content) = item {
-        let noteStickerCell = tableView.dequeue(NoteStickerCell.self, indexPath: indexPath)
-        return noteStickerCell
+        let noteDetailTextContentCell = tableView.dequeue(NoteDetailTextContentCell.self, indexPath: indexPath)
+        noteDetailTextContentCell.configure(content: content)
+        return noteDetailTextContentCell
       }
       
       return UITableViewCell()
@@ -65,6 +67,10 @@ final class NoteDetailViewController: BaseViewController<NoteDetailReactor> {
     $0.register(NoteDetailTitleCell.self)
     $0.register(NoteDetailTextContentCell.self)
   }
+  
+  private let moreDetailButton = UIBarButtonItem().then {
+    $0.image = UIImage(type: .moreButton)
+  }
 
   // MARK: Initializing
 
@@ -83,6 +89,8 @@ final class NoteDetailViewController: BaseViewController<NoteDetailReactor> {
   override func configureUI() {
     super.configureUI()
     self.view.addSubviews(tableView)
+    navigationItem.rightBarButtonItems = [moreDetailButton]
+    bindUI()
   }
 
   override func configureConstraints() {
@@ -122,4 +130,44 @@ final class NoteDetailViewController: BaseViewController<NoteDetailReactor> {
       .bind(to: tableView.rx.items(dataSource: dataSource))
       .disposed(by: disposeBag)
   }
+  
+  private func bindUI() {
+    moreDetailButton.rx.tap.asDriver()
+      .drive { [weak self] _ in
+        guard let self = self else { return }
+        let actionSheet = UIAlertController(
+          title: nil,
+          message: nil,
+          preferredStyle: .actionSheet
+        )
+        
+        actionSheet.addAction(
+          UIAlertAction(
+            title: "노트 삭제",
+            style: .destructive,
+            handler: nil
+          )
+        )
+        
+        actionSheet.addAction(
+          UIAlertAction(
+            title: "노트 수정",
+            style: .default,
+            handler: nil
+          )
+        )
+        
+        actionSheet.addAction(
+          UIAlertAction(
+            title: "취소",
+            style: .cancel,
+            handler: nil
+          )
+        )
+        self.present(actionSheet, animated: true, completion: nil)
+    }
+    .disposed(by: disposeBag)
+
+  }
+  
 }

--- a/Tooda/Sources/Scenes/NoteList/NoteListViewController.swift
+++ b/Tooda/Sources/Scenes/NoteList/NoteListViewController.swift
@@ -39,10 +39,6 @@ final class NoteListViewController: BaseViewController<NoteListReactor> {
     $0.image = UIImage(type: .searchBarButton)
   }
   
-  private let moreDetailButton = UIBarButtonItem().then {
-    $0.image = UIImage(type: .moreButton)
-  }
-  
   private let emptyDefaultView = UIView().then {
     $0.backgroundColor = .gray5
   }
@@ -89,11 +85,6 @@ final class NoteListViewController: BaseViewController<NoteListReactor> {
   }
   
   // MARK: - Overridden: ParentClass
-  
-  override func viewDidLoad() {
-    super.viewDidLoad()
-    bindUI()
-  }
   
   override func bind(reactor: NoteListReactor) {
     rx.viewWillAppear.take(1)
@@ -159,46 +150,11 @@ final class NoteListViewController: BaseViewController<NoteListReactor> {
       .disposed(by: disposeBag)
   }
   
-  private func bindUI() {
-    
-    moreDetailButton.rx.tap.asDriver()
-      .drive { [weak self] _ in
-        guard let self = self else { return }
-        let actionSheet = UIAlertController(
-          title: nil,
-          message: nil,
-          preferredStyle: .actionSheet
-        )
-        
-        actionSheet.addAction(
-          UIAlertAction(
-            title: "다이어리 삭제",
-            style: .destructive,
-            handler: nil
-          )
-        )
-        
-        actionSheet.addAction(
-          UIAlertAction(
-            title: "취소",
-            style: .cancel,
-            handler: nil
-          )
-        )
-        self.present(actionSheet, animated: true, completion: nil)
-    }
-    .disposed(by: disposeBag)
-
-  }
-  
   // MARK: - configureUI
   
   override func configureUI() {
     navigationItem.leftBarButtonItem = dismissBarButton
-    navigationItem.rightBarButtonItems = [
-      moreDetailButton,
-      searchBarButton
-    ]
+    navigationItem.rightBarButtonItem = searchBarButton
     navigationController?.navigationBar.backgroundColor = .white
     UIApplication.shared.statusBarUIView?.backgroundColor = .white
     view.addSubviews(


### PR DESCRIPTION
### 수정내역 (필수)
- 셀 데이터 연결
- 노트 리스트 네이게이션 버튼 스펙 아웃에 맞춰 정리
- 노트 디테일 화면 3 dots 버튼 추가 (네이게이션바가 겹치는 이슈 수정 필요)

### 스크린샷 (선택사항)
<img width="536" alt="스크린샷 2022-01-25 오후 5 56 01" src="https://user-images.githubusercontent.com/31857308/151325131-a7c92f12-8651-4402-abbe-df8a85edfa81.PNG">
