### PR TITLE
[Domain] 노트 상세 화면에서 종목과 링크 아이템을 볼 수 있어요.

### DIFF
--- a/Tooda/Sources/Core/AppFactory.swift
+++ b/Tooda/Sources/Core/AppFactory.swift
@@ -186,6 +186,7 @@ final class AppFactory: AppFactoryType {
         dependency: .init(
           service: self.dependency.appInject.resolve(NetworkingProtocol.self),
           coordinator: self.dependency.appInject.resolve(AppCoordinatorType.self),
+          linkPreviewService: self.dependency.appInject.resolve(LinkPreViewServiceType.self),
           payload: payload
         )
       )

--- a/Tooda/Sources/Scenes/NoteDetail/NoteDetailReactor.swift
+++ b/Tooda/Sources/Scenes/NoteDetail/NoteDetailReactor.swift
@@ -93,6 +93,16 @@ extension NoteDetailReactor {
           items: stockSectionItems ?? []
         )
         
+        let linkSectionItems = note.noteLinks?
+          .compactMap { $0.url }
+          .map { NoteLinkCellReactor.init(dependency: .init(service: self.dependency.linkPreviewService), payload: $0) }
+          .map { NoteDetailSectionItem.link($0) }
+        
+        let linkSection = NoteDetailSection(
+          identity: .link,
+          items: linkSectionItems ?? []
+        )
+        
         let sectionModels = [
           NoteDetailSection(
             identity: .header,
@@ -102,7 +112,8 @@ extension NoteDetailReactor {
               .content(note.content)
             ]
           ),
-          stockSection
+          stockSection,
+          linkSection
         ]
         return Observable<Mutation>.just(
           Mutation.setNoteDetailSectionModel(sectionModels)

--- a/Tooda/Sources/Scenes/NoteDetail/NoteDetailReactor.swift
+++ b/Tooda/Sources/Scenes/NoteDetail/NoteDetailReactor.swift
@@ -21,6 +21,7 @@ final class NoteDetailReactor: Reactor {
   struct Dependency {
     let service: NetworkingProtocol
     let coordinator: AppCoordinatorType
+    let linkPreviewService: LinkPreViewServiceType
     let payload: Payload
   }
 

--- a/Tooda/Sources/Scenes/NoteDetail/NoteDetailReactor.swift
+++ b/Tooda/Sources/Scenes/NoteDetail/NoteDetailReactor.swift
@@ -82,6 +82,16 @@ extension NoteDetailReactor {
       .map(Note.self)
       .asObservable()
       .flatMap { note -> Observable<Mutation> in
+        
+        let stockSectionItems = note.noteStocks?
+          .map { NoteStockCellReactor.init(payload: .init(name: $0.name, rate: $0.changeRate ?? 0.0)) }
+          .map { NoteDetailSectionItem.stock($0) }
+        
+        let stockSection = NoteDetailSection(
+          identity: .stock,
+          items: stockSectionItems ?? []
+        )
+        
         let sectionModels = [
           NoteDetailSection(
             identity: .header,
@@ -90,7 +100,8 @@ extension NoteDetailReactor {
               .title(note.title, note.updatedAt ?? note.createdAt),
               .content(note.content)
             ]
-          )
+          ),
+          stockSection
         ]
         return Observable<Mutation>.just(
           Mutation.setNoteDetailSectionModel(sectionModels)

--- a/Tooda/Sources/Scenes/NoteDetail/NoteDetailViewController.swift
+++ b/Tooda/Sources/Scenes/NoteDetail/NoteDetailViewController.swift
@@ -47,7 +47,13 @@ final class NoteDetailViewController: BaseViewController<NoteDetailReactor> {
     case .image:
       return UITableViewCell()
     case .link:
-      return UITableViewCell()
+        if case let .link(reactor) = item {
+          let cell = tableView.dequeue(NoteLinkCell.self, indexPath: indexPath)
+          cell.configure(reactor: reactor)
+          return cell
+        }
+        
+        return UITableViewCell()
     case .stock:
       if case let .stock(reactor) = item {
         let cell = tableView.dequeue(NoteStockCell.self, indexPath: indexPath)
@@ -73,6 +79,7 @@ final class NoteDetailViewController: BaseViewController<NoteDetailReactor> {
     $0.register(NoteDetailTitleCell.self)
     $0.register(NoteDetailTextContentCell.self)
     $0.register(NoteStockCell.self)
+    $0.register(NoteLinkCell.self)
   }
   
   private let moreDetailButton = UIBarButtonItem().then {

--- a/Tooda/Sources/Scenes/NoteDetail/NoteDetailViewController.swift
+++ b/Tooda/Sources/Scenes/NoteDetail/NoteDetailViewController.swift
@@ -49,6 +49,12 @@ final class NoteDetailViewController: BaseViewController<NoteDetailReactor> {
     case .link:
       return UITableViewCell()
     case .stock:
+      if case let .stock(reactor) = item {
+        let cell = tableView.dequeue(NoteStockCell.self, indexPath: indexPath)
+        cell.configure(with: reactor)
+        return cell
+      }
+      
       return UITableViewCell()
     }
   })
@@ -66,6 +72,7 @@ final class NoteDetailViewController: BaseViewController<NoteDetailReactor> {
     $0.register(NoteStickerCell.self)
     $0.register(NoteDetailTitleCell.self)
     $0.register(NoteDetailTextContentCell.self)
+    $0.register(NoteStockCell.self)
   }
   
   private let moreDetailButton = UIBarButtonItem().then {

--- a/Tooda/Sources/Scenes/NoteList/NoteListViewController.swift
+++ b/Tooda/Sources/Scenes/NoteList/NoteListViewController.swift
@@ -43,12 +43,11 @@ final class NoteListViewController: BaseViewController<NoteListReactor> {
     $0.backgroundColor = .gray5
   }
   
-  private lazy var tableView = UITableView().then {
+  private let tableView = UITableView().then {
     $0.backgroundColor = .gray5
     $0.register(UITableViewCell.self)
     $0.register(NoteListCell.self)
     $0.separatorStyle = .none
-    $0.delegate = self
   }
   
   private let dismissBarButton = UIBarButtonItem(


### PR DESCRIPTION
### 수정내역 (필수)
**셀의 디자인은 등록 화면 것을 그대로 사용하고 있어 일부 차이가 있을 수 있어요, 추후 QA때 조정할 예정입니다. 🙇🏻‍♂️**
- 노트 상세 화면에 LinkPreview Dependency를 추가했어요.
- 노트 상세 화면 tableView에 종목, 링크 Cell을 등록하고 DataSource 코드를 구현했어요.
- 노트 상세 화면 Reator에서 종목과 링크 갯수에 따른 SectionItem을 만들고 각각의 Section에 넣어줘요.
- 노트 상세 화면 tableView의 타입을 let으로 변경하고, 중복된 Delegate 설정 코드를 제거했어요.

### 스크린샷 (선택사항)
<img src="https://user-images.githubusercontent.com/19662529/151397763-19e11246-8b18-4605-a2a0-87e004b0f83e.PNG" width=320>

