### PR TITLE
[Domain] 노트 상세 화면에서 노트를 수정할 수 있어요.

### DIFF
--- a/Tooda/Sources/Core/AppFactory.swift
+++ b/Tooda/Sources/Core/AppFactory.swift
@@ -48,10 +48,10 @@ final class AppFactory: AppFactoryType {
           linkPreviewService:
             self.dependency.appInject.resolve(LinkPreViewServiceType.self),
           createDiarySectionFactory: createDiarySectionFactory,
-          modifiableNoteSectionFactory: nil,
-          updateCompletionRelay: nil
+          modifiableNoteSectionFactory: nil
         ),
-        modifiableNote: nil
+        modifiableNote: nil,
+        payload: .init(updateCompletionRelay: nil)
       )
         
       let viewController = CreateNoteViewController(dateString: today, reactor: reactor, mode: .add)
@@ -68,10 +68,10 @@ final class AppFactory: AppFactoryType {
             linkPreviewService:
               self.dependency.appInject.resolve(LinkPreViewServiceType.self),
             createDiarySectionFactory: nil,
-            modifiableNoteSectionFactory: modifiableNoteSectionFactory,
-            updateCompletionRelay: updateCompletionRelay
+            modifiableNoteSectionFactory: modifiableNoteSectionFactory
           ),
-          modifiableNote: note
+          modifiableNote: note,
+          payload: .init(updateCompletionRelay: nil)
         )
         
         let viewController = CreateNoteViewController(dateString: dateString, reactor: reactor, mode: .update)

--- a/Tooda/Sources/Core/AppFactory.swift
+++ b/Tooda/Sources/Core/AppFactory.swift
@@ -59,7 +59,7 @@ final class AppFactory: AppFactoryType {
       navigationController.modalPresentationStyle = .overFullScreen
       return navigationController
         
-    case .modifyNote(let dateString, let note):
+    case .modifyNote(let dateString, let note, let updateCompletionRelay):
         let reactor = CreateNoteViewReactor(
           dependency: .init(
             service: self.dependency.appInject.resolve(NetworkingProtocol.self),
@@ -69,7 +69,7 @@ final class AppFactory: AppFactoryType {
               self.dependency.appInject.resolve(LinkPreViewServiceType.self),
             createDiarySectionFactory: nil,
             modifiableNoteSectionFactory: modifiableNoteSectionFactory,
-            updateCompletionRelay: nil
+            updateCompletionRelay: updateCompletionRelay
           ),
           modifiableNote: note
         )

--- a/Tooda/Sources/Core/AppFactory.swift
+++ b/Tooda/Sources/Core/AppFactory.swift
@@ -48,7 +48,8 @@ final class AppFactory: AppFactoryType {
           linkPreviewService:
             self.dependency.appInject.resolve(LinkPreViewServiceType.self),
           createDiarySectionFactory: createDiarySectionFactory,
-          modifiableNoteSectionFactory: nil
+          modifiableNoteSectionFactory: nil,
+          updateCompletionRelay: nil
         ),
         modifiableNote: nil
       )
@@ -67,7 +68,8 @@ final class AppFactory: AppFactoryType {
             linkPreviewService:
               self.dependency.appInject.resolve(LinkPreViewServiceType.self),
             createDiarySectionFactory: nil,
-            modifiableNoteSectionFactory: modifiableNoteSectionFactory
+            modifiableNoteSectionFactory: modifiableNoteSectionFactory,
+            updateCompletionRelay: nil
           ),
           modifiableNote: note
         )

--- a/Tooda/Sources/Core/Coordinator/Scene.swift
+++ b/Tooda/Sources/Core/Coordinator/Scene.swift
@@ -16,7 +16,7 @@ enum Scene {
   case login
   case home
   case createNote(dateString: String)
-  case modifyNote(dateString: String, note: NoteRequestDTO)
+  case modifyNote(dateString: String, note: NoteRequestDTO, updateCompletonRelay: PublishRelay<Note>?)
   case settings
   case addStock(completion: PublishRelay<NoteStock>)
   case search

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -224,6 +224,7 @@ final class CreateNoteViewReactor: Reactor {
         
         return .just(.present(.showPhotoPicker))
       case .item:
+        self.noteRequestDTO.images.remove(at: indexPath.row)
         imageCellReactor.action.onNext(.removeImage(indexPath))
     }
     

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -408,9 +408,9 @@ extension CreateNoteViewReactor {
     return self.dependency.service.request(NoteAPI.update(dto: self.noteRequestDTO))
       .map(Note.self)
       .asObservable()
-      .map { String($0.id) }
-      .flatMap { [weak self] noteID -> Observable<Mutation> in
-        if noteID.isNotEmpty {
+      .flatMap { [weak self] note -> Observable<Mutation> in
+        if "\(note.id)".isNotEmpty {
+          self?.dependency.updateCompletionRelay?.accept(note)
           return self?.dismissView() ?? .empty()
         } else {
           return .empty()

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -22,13 +22,32 @@ final class CreateNoteViewReactor: Reactor {
   
   let scheduler: Scheduler = MainScheduler.asyncInstance
 
-  struct Dependency {
+  class Dependency {
     let service: NetworkingProtocol
     let coordinator: AppCoordinatorType
     let authorization: AppAuthorizationType
     let linkPreviewService: LinkPreViewServiceType
     let createDiarySectionFactory: CreateNoteSectionType?
     let modifiableNoteSectionFactory: ModifiableNoteSectionType?
+    weak var updateCompletionRelay: PublishRelay<Note>?
+    
+    init(
+      service: NetworkingProtocol,
+      coordinator: AppCoordinatorType,
+      authorization: AppAuthorizationType,
+      linkPreviewService: LinkPreViewServiceType,
+      createDiarySectionFactory: CreateNoteSectionType?,
+      modifiableNoteSectionFactory: ModifiableNoteSectionType?,
+      updateCompletionRelay: PublishRelay<Note>?
+    ) {
+      self.service = service
+      self.coordinator = coordinator
+      self.authorization = authorization
+      self.linkPreviewService = linkPreviewService
+      self.createDiarySectionFactory = createDiarySectionFactory
+      self.modifiableNoteSectionFactory = modifiableNoteSectionFactory
+      self.updateCompletionRelay = updateCompletionRelay
+    }
   }
 
   enum Action {

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -197,14 +197,11 @@ final class CreateNoteViewReactor: Reactor {
         .take(self.linkItemMaxCount)
         .map { Action.linkURLDidAdded($0) },
       self.addStickerCompletionRelay
-        .map { Action.stckerDidPicked($0) }
-        .debounce(.milliseconds(300), scheduler: MainScheduler.asyncInstance),
+        .map { Action.stckerDidPicked($0) },
       self.stockItemEditCompletionRelay
-        .map { Action.stockItemDidUpdated($0) }
-        .debounce(.microseconds(300), scheduler: MainScheduler.asyncInstance),
+        .map { Action.stockItemDidUpdated($0) },
       self.updateStickerCompletionRelay
         .map { Action.updateStikcerDidPicked($0) }
-        .debounce(.microseconds(300), scheduler: MainScheduler.asyncInstance)
     )
   }
 

--- a/Tooda/Sources/Scenes/NoteDetail/NoteDetailReactor.swift
+++ b/Tooda/Sources/Scenes/NoteDetail/NoteDetailReactor.swift
@@ -35,11 +35,13 @@ final class NoteDetailReactor: Reactor {
 
   enum Mutation {
     case setNoteDetailSectionModel([NoteDetailSection])
+    case fetchNote(Note)
   }
 
   struct State {
     var sectionModel: [NoteDetailSection]
     let noteID: Int
+    var note: Note?
     
     static func generateInitialState(noteID: Int) -> State {
       return State(sectionModel: [], noteID: noteID)
@@ -118,10 +120,12 @@ extension NoteDetailReactor {
           stockSection,
           linkSection
         ]
-        return Observable<Mutation>.just(
-          Mutation.setNoteDetailSectionModel(sectionModels)
-        )
+        return Observable<Mutation>.concat([
+          .just(Mutation.setNoteDetailSectionModel(sectionModels)),
+          .just(Mutation.fetchNote(note))
+        ])
       }
+  }
   }
 }
 
@@ -136,6 +140,8 @@ extension NoteDetailReactor {
     switch mutation {
     case let .setNoteDetailSectionModel(sectionModel):
       newState.sectionModel = sectionModel
+    case let .fetchNote(note):
+      newState.note = note
     }
     
     return newState

--- a/Tooda/Sources/Scenes/NoteDetail/NoteDetailReactor.swift
+++ b/Tooda/Sources/Scenes/NoteDetail/NoteDetailReactor.swift
@@ -79,6 +79,7 @@ extension NoteDetailReactor {
       )
       return .empty()
       case .editNote:
+        self.editNote()
         return .empty()
     }
   }
@@ -126,6 +127,23 @@ extension NoteDetailReactor {
         ])
       }
   }
+  
+  private func editNote() {
+    guard let note = self.currentState.note else { return }
+    
+    let noteRequestDTO = NoteRequestDTO(id: "\(note.id)",
+                                        updatedAt: note.updatedAt,
+                                        createdAt: note.createdAt,
+                                        title: note.title,
+                                        content: note.content,
+                                        stocks: note.noteStocks?.map { $0 } ?? [],
+                                        links: note.noteLinks?.compactMap { $0.url } ?? [],
+                                        images: note.noteImages.map { $0.imageURL },
+                                        sticker: note.sticker ?? .wow)
+    
+    let dateString = note.createdAt?.convertToDate()?.string(.dot) ?? ""
+    
+    self.dependency.coordinator.transition(to: .modifyNote(dateString: dateString, note: noteRequestDTO), using: .modal, animated: true, completion: nil)
   }
 }
 

--- a/Tooda/Sources/Scenes/NoteDetail/NoteDetailReactor.swift
+++ b/Tooda/Sources/Scenes/NoteDetail/NoteDetailReactor.swift
@@ -30,6 +30,7 @@ final class NoteDetailReactor: Reactor {
   enum Action {
     case loadData
     case back
+    case editNote
   }
 
   enum Mutation {
@@ -75,6 +76,8 @@ extension NoteDetailReactor {
         completion: nil
       )
       return .empty()
+      case .editNote:
+        return .empty()
     }
   }
   

--- a/Tooda/Sources/Scenes/NoteDetail/NoteDetailViewController.swift
+++ b/Tooda/Sources/Scenes/NoteDetail/NoteDetailViewController.swift
@@ -65,6 +65,9 @@ final class NoteDetailViewController: BaseViewController<NoteDetailReactor> {
     }
   })
   
+  
+  private let editNoteButtonRelay: PublishRelay<Void> = PublishRelay()
+  
   // MARK: UI Properties
   
   private let tableView = UITableView().then {
@@ -139,6 +142,11 @@ final class NoteDetailViewController: BaseViewController<NoteDetailReactor> {
       .bind(to: reactor.action)
       .disposed(by: self.disposeBag)
     
+    self.editNoteButtonRelay
+      .map { NoteDetailReactor.Action.editNote }
+      .bind(to: reactor.action)
+      .disposed(by: self.disposeBag)
+    
     reactor.state
       .map { $0.sectionModel }
       .bind(to: tableView.rx.items(dataSource: dataSource))
@@ -167,7 +175,9 @@ final class NoteDetailViewController: BaseViewController<NoteDetailReactor> {
           UIAlertAction(
             title: "노트 수정",
             style: .default,
-            handler: nil
+            handler: { [weak self] _ in
+              self?.editNoteButtonRelay.accept(())
+            }
           )
         )
         

--- a/Tooda/Sources/Scenes/OneLineReviewPopUp/PopUpReactor.swift
+++ b/Tooda/Sources/Scenes/OneLineReviewPopUp/PopUpReactor.swift
@@ -115,15 +115,15 @@ extension PopUpReactor {
   }
   
   private func didTapBottonButtonMutation() -> Observable<Mutation> {
-    if let selectedSticker = currentState.selectedSticker,
-      case let .list(relay) = dependency.type {
-        relay.accept(selectedSticker)
-    }
-    
     dependency.coordinator.close(
       style: .dismiss,
       animated: false,
-      completion: nil
+      completion: { [weak self] in
+        if let selectedSticker = self?.currentState.selectedSticker,
+           case let .list(relay) = self?.dependency.type {
+          relay.accept(selectedSticker)
+        }
+      }
     )
     
     return Observable<Mutation>.empty()


### PR DESCRIPTION
### 수정내역 (필수)
- 노트 상세 화면에서 노트 수정 Alert을 탭 하면 노트 수정 화면을 호출 할 수 있어요.
- 노트 상세 화면에서 Reactor State에 Note 멤버변수를 추가했어요.
- 노트 상세 화면에서 노트 수정화면을 호출 할 때 이벤트를 전달받기 위한 updateRelay를 추가했어요.
- 노트 입력 화면의 Dependency를 클래스 타입으로 바꾸고, updateRelay 프로퍼티를 추가했어요.
- Scene에 노트 수정 Case에 updateRelay 연관 프로퍼티를 추가했어요.
- 노트 입력 화면에서 노트 수정 버튼을 누르면 노트 수정 API를 호출하고 이전 화면에 Relay 이벤트를 전달해요.
- 노트 입력 화면에서 이미지 삭제 버튼을 누르면 RequestDTO에서도 해당 이미지 배열을 제거하는 코드를 추가했어요.

### 스크린샷 (선택사항)
![ezgif com-gif-maker (14)](https://user-images.githubusercontent.com/19662529/151548985-bf0004b9-c76a-4691-a1e6-88156b9afe38.gif)

### Todo(@woookDev님, 요청드립니다!!)
- [ ] : 노트 수정 버튼을 눌렀을 때, 호출되는 팝업의 문구를 변경해요.
- [ ] : 노트 수정 버튼을 눌렀을 때 상세 화면에서 전달받은 스티커를 초기값으로 포커싱해줘요.
