### PR TITLE
[Core] 노트에 대한 글로벌 이벤트버스를 추가하고 홈화면에 대응을 합니다. 

### DIFF
--- a/Tooda/Sources/Core/AppFactory.swift
+++ b/Tooda/Sources/Core/AppFactory.swift
@@ -34,7 +34,8 @@ final class AppFactory: AppFactoryType {
       let reactor = HomeReactor(
         dependency: .init(
           service: self.dependency.appInject.resolve(NetworkingProtocol.self),
-          coordinator: self.dependency.appInject.resolve(AppCoordinatorType.self)
+          coordinator: self.dependency.appInject.resolve(AppCoordinatorType.self),
+          noteEventBus: NoteEventBus.event.asObservable()
         )
       )
       return HomeViewController(reactor: reactor)

--- a/Tooda/Sources/Core/GlobalEventBus/NoteEventBus.swift
+++ b/Tooda/Sources/Core/GlobalEventBus/NoteEventBus.swift
@@ -1,0 +1,19 @@
+//
+//  NoteEventBus.swift
+//  Tooda
+//
+//  Created by Jinsu Park on 2022/01/23.
+//
+
+import RxSwift
+
+enum NoteEventBus {
+
+  static let event = PublishSubject<Event>()
+
+  enum Event {
+    case createNote(Note)
+    case editNode(Note)
+    case deleteNote(Note)
+  }
+}

--- a/Tooda/Sources/Entities/Note/Note.swift
+++ b/Tooda/Sources/Entities/Note/Note.swift
@@ -21,8 +21,8 @@ struct Note: Codable, IdentifiableType, Equatable {
   var id: Int
   var title: String
   var content: String
-  var createdAt: String?
-  var updatedAt: String?
+  var createdAt: Date?
+  var updatedAt: Date?
   var sticker: Sticker?
   var noteStocks: [NoteStock]?
   var noteLinks: [NoteLink]?

--- a/Tooda/Sources/Scenes/Home/HomeReactor.swift
+++ b/Tooda/Sources/Scenes/Home/HomeReactor.swift
@@ -182,6 +182,77 @@ extension HomeReactor {
 }
 
 
+// MARK: - Transform
+
+extension HomeReactor {
+
+  func transform(mutation: Observable<Mutation>) -> Observable<Mutation> {
+    return Observable.merge(
+      mutation,
+      self.dependency.noteEventBus
+        .flatMap { event -> Observable<Mutation> in
+          switch event {
+          case let .createNote(note):
+            return self.createNoteEventBusMutaion(note)
+
+          default:
+            return .empty()
+          }
+        }
+    )
+  }
+
+  private func createNoteEventBusMutaion(_ note: Note) -> Observable<Mutation> {
+    guard let newNoteYear = note.createdAt?.year,
+          let newNoteMonth = note.createdAt?.month else { return .empty() }
+
+    if self.currentState.notebooks.isEmpty {
+      return .just(
+        .setNotebooks([
+          .init(
+            year: newNoteYear,
+            month: newNoteMonth,
+            noteCount: 1,
+            createdAt: note.createdAt,
+            updatedAt: note.updatedAt,
+            stickers: note.sticker == nil ? [] : [note.sticker!]
+          )
+        ])
+      )
+    }
+
+    if let index = self.currentState.notebooks.firstIndex(where: {
+      $0.year == newNoteYear && $0.month == newNoteMonth
+    }) {
+      var notebooks = self.currentState.notebooks
+      notebooks[index].noteCount += 1
+      notebooks[index].updatedAt = note.updatedAt
+      if notebooks[index].stickers.count < 3,
+         let sticker = note.sticker {
+        notebooks[index].stickers.append(sticker)
+      }
+      return .just(
+        .setNotebooks(notebooks)
+      )
+    }
+
+    // NOTE: 오늘만 생성했을 때만 가능한 로직
+    var notebooks = self.currentState.notebooks
+    notebooks.append(.init(
+      year: newNoteYear,
+      month: newNoteMonth,
+      noteCount: 1,
+      createdAt: note.createdAt,
+      updatedAt: note.updatedAt,
+      stickers: note.sticker == nil ? [] : [note.sticker!]
+    ))
+    return .just(
+      .setNotebooks(notebooks)
+    )
+  }
+}
+
+
 // MARK: - Reduce
 
 extension HomeReactor {

--- a/Tooda/Sources/Scenes/Home/HomeReactor.swift
+++ b/Tooda/Sources/Scenes/Home/HomeReactor.swift
@@ -18,6 +18,7 @@ final class HomeReactor: Reactor {
   struct Dependency {
     let service: NetworkingProtocol
     let coordinator: AppCoordinatorType
+    let noteEventBus: Observable<NoteEventBus.Event>
   }
 
 

--- a/Tooda/Sources/Scenes/Home/HomeReactor.swift
+++ b/Tooda/Sources/Scenes/Home/HomeReactor.swift
@@ -260,7 +260,6 @@ extension HomeReactor {
     }) else { return .empty() }
 
     var notebooks = self.currentState.notebooks
-    notebooks[index].noteCount += 1
     notebooks[index].updatedAt = note.updatedAt
 
     return .just(

--- a/Tooda/Sources/Scenes/Home/HomeReactor.swift
+++ b/Tooda/Sources/Scenes/Home/HomeReactor.swift
@@ -198,8 +198,8 @@ extension HomeReactor {
           case let .editNode(note):
             return self.editNoteEventBusMutaion(note)
 
-          default:
-            return .empty()
+          case let .deleteNote(note):
+            return self.deleteNoteEventBusMutation(note)
           }
         }
     )
@@ -262,6 +262,24 @@ extension HomeReactor {
     var notebooks = self.currentState.notebooks
     notebooks[index].noteCount += 1
     notebooks[index].updatedAt = note.updatedAt
+
+    return .just(
+      .setNotebooks(notebooks)
+    )
+  }
+
+  private func deleteNoteEventBusMutation(_ note: Note) -> Observable<Mutation> {
+    guard let index = self.currentState.notebooks.firstIndex(where: {
+      $0.year == note.createdAt?.year && $0.month == note.createdAt?.month
+    }) else { return .empty() }
+
+    var notebooks = self.currentState.notebooks
+    if notebooks[index].noteCount >= 2 {
+      notebooks[index].noteCount -= 1
+      notebooks[index].updatedAt = Date()
+    } else {
+      notebooks.remove(at: index)
+    }
 
     return .just(
       .setNotebooks(notebooks)

--- a/Tooda/Sources/Scenes/Home/HomeReactor.swift
+++ b/Tooda/Sources/Scenes/Home/HomeReactor.swift
@@ -195,6 +195,9 @@ extension HomeReactor {
           case let .createNote(note):
             return self.createNoteEventBusMutaion(note)
 
+          case let .editNode(note):
+            return self.editNoteEventBusMutaion(note)
+
           default:
             return .empty()
           }
@@ -246,6 +249,20 @@ extension HomeReactor {
       updatedAt: note.updatedAt,
       stickers: note.sticker == nil ? [] : [note.sticker!]
     ))
+    return .just(
+      .setNotebooks(notebooks)
+    )
+  }
+
+  private func editNoteEventBusMutaion(_ note: Note) -> Observable<Mutation> {
+    guard let index = self.currentState.notebooks.firstIndex(where: {
+      $0.year == note.createdAt?.year && $0.month == note.createdAt?.month
+    }) else { return .empty() }
+
+    var notebooks = self.currentState.notebooks
+    notebooks[index].noteCount += 1
+    notebooks[index].updatedAt = note.updatedAt
+
     return .just(
       .setNotebooks(notebooks)
     )

--- a/Tooda/Sources/Scenes/NoteList/Cells/NoteListCell.swift
+++ b/Tooda/Sources/Scenes/NoteList/Cells/NoteListCell.swift
@@ -138,8 +138,7 @@ final class NoteListCell: BaseTableViewCell {
     selectionStyle = .none
     emojiImageView.image = note.sticker?.image
     titleLabel.attributedText = note.title.styled(with: Font.title)
-    if let dateString = note.createdAt,
-       let date = dateString.convertToDate(),
+    if let date = note.createdAt,
        let weekName = Date.WeekDay(rawValue: date.weekday)?.name {
       
       recordDateLabel.attributedText = "\(date.string(.dot)) (\(weekName)) \(date.hour):\(date.minute) 기록".styled(with: Font.recordDate)

--- a/Tooda/Sources/Scenes/Search/SearchResult/SearchResultReactor.swift
+++ b/Tooda/Sources/Scenes/Search/SearchResult/SearchResultReactor.swift
@@ -72,8 +72,8 @@ extension SearchResultReactor {
           id: 1,
           title: "전기차 관련 ",
           content: "#전기차  G전자는 자동차 업체는 아니기 때문에, 유명 완성차 업체에 납품을 할 때 중요한 트랙 레코드가 많진 않아요. 반면 마그나는 수십 개 자동차 업체에 부품을 납품한 회사니깐 이 둘이 합치면 시너지를 낼 수 있을 까라 ",
-          createdAt: "2021-05-19T06:41:45.051Z",
-          updatedAt: "2021-05-19T06:41:45.051Z",
+          createdAt: Date(),
+          updatedAt: Date(),
           sticker: .angry,
           noteStocks: [
             .init(
@@ -92,8 +92,8 @@ extension SearchResultReactor {
           id: 2,
           title: "전기차 관련 ",
           content: "#전기차  G전자는 자동차 업체는 아니기 때문에, 유명 완성차 업체에 납품을 할 때 중요한 트랙 레코드가 많진 않아요. 반면 마그나는 수십 개 자동차 업체에 부품을 납품한 회사니깐 이 둘이 합치면 시너지를 낼 수 있을 까라 ",
-          createdAt: "2021-05-19T06:41:45.051Z",
-          updatedAt: "2021-05-19T06:41:45.051Z",
+          createdAt: Date(),
+          updatedAt: Date(),
           sticker: .thinking,
           noteStocks: [
             .init(
@@ -112,8 +112,8 @@ extension SearchResultReactor {
           id: 3,
           title: "전기차 관련 ",
           content: "#전기차  G전자는 자동차 업체는 아니기 때문에, 유명 완성차 업체에 납품을 할 때 중요한 트랙 레코드가 많진 않아요. 반면 마그나는 수십 개 자동차 업체에 부품을 납품한 회사니깐 이 둘이 합치면 시너지를 낼 수 있을 까라 ",
-          createdAt: "2021-05-19T06:41:45.051Z",
-          updatedAt: "2021-05-19T06:41:45.051Z",
+          createdAt: Date(),
+          updatedAt: Date(),
           sticker: .sad,
           noteStocks: [
             .init(


### PR DESCRIPTION
### 수정내역 (필수)
- 이벤트버스 추가하고 홈화면에 대응했어요.
- 다들 한번 로직 확인해주세요.
  - 노트 리스트 화면, 검색 화면, 홈화면: create, edit, delete 이벤트 처리
  - 노트 작성 화면:  create, edit, delete 이벤트 방출
