### PR TITLE
[Core] 화면이 dismiss 될 때, completion이 두번 호출될 수 있는 문제를 수정했어요.

### DIFF
--- a/Tooda/Sources/Core/Coordinator/AppCoordinator.swift
+++ b/Tooda/Sources/Core/Coordinator/AppCoordinator.swift
@@ -151,13 +151,13 @@ final class AppCoordinator: AppCoordinatorType {
       completion?()
       
     case .dismiss:
-      currentViewController.dismiss(animated: animated, completion: completion)
-
       if let presentingViewController = currentViewController.presentingViewController {
         currentViewController.dismiss(animated: animated, completion: {
           self.currentViewController = presentingViewController
           completion?()
         })
+      } else {
+        currentViewController.dismiss(animated: animated, completion: completion)
       }
     }
   }


### PR DESCRIPTION
### 수정내역 (필수)
- Coordinator의 Dismiss 로직에서 completion이 2번 발생할 수 있는 문제를 수정했어요.

### 스크린샷 (선택사항)
|수정 전|수정 후|
|---------------------------|---------------------------|
|![ezgif com-gif-maker](https://user-images.githubusercontent.com/19662529/151697992-d288ebd6-9287-4ce3-8127-dcf897bb580c.gif)|![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/19662529/151697996-69fda883-7424-43d9-a546-8bc0a0b09f6f.gif)|

