### PR TITLE
[Domain] 노트 상세 화면에서 노트 수정에 대한 콜백을 받지 못하는 문제를 수정했어요.

### DIFF
--- a/Tooda/Sources/Core/AppFactory.swift
+++ b/Tooda/Sources/Core/AppFactory.swift
@@ -71,7 +71,7 @@ final class AppFactory: AppFactoryType {
             modifiableNoteSectionFactory: modifiableNoteSectionFactory
           ),
           modifiableNote: note,
-          payload: .init(updateCompletionRelay: nil)
+          payload: .init(updateCompletionRelay: updateCompletionRelay)
         )
         
         let viewController = CreateNoteViewController(dateString: dateString, reactor: reactor, mode: .update)

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -447,13 +447,23 @@ extension CreateNoteViewReactor {
       .map(Note.self)
       .asObservable()
       .flatMap { [weak self] note -> Observable<Mutation> in
-        if "\(note.id)".isNotEmpty {
-          self?.payload.updateCompletionRelay?.accept(note)
-          return self?.dismissView() ?? .empty()
-        } else {
-          return .empty()
-        }
+        return self?.dimissViewWithUpdateCompletion(note) ?? .empty()
       }
+  }
+  
+  private func dimissViewWithUpdateCompletion(_ note: Note) -> Observable<Mutation> {
+    
+    guard "\(note.id)".isNotEmpty else { return .empty() }
+    
+    self.dependency.coordinator.close(
+      style: .dismiss,
+      animated: true,
+      completion: { [weak self] in
+        self?.payload.updateCompletionRelay?.accept(note)
+      }
+    )
+    
+    return .empty()
   }
 }
 

--- a/Tooda/Sources/Scenes/NoteDetail/NoteDetailReactor.swift
+++ b/Tooda/Sources/Scenes/NoteDetail/NoteDetailReactor.swift
@@ -69,8 +69,6 @@ final class NoteDetailReactor: Reactor {
       action,
       self.noteUpdateCompletionRelay
         .map { _ in Action.loadData }
-        .debug()
-        .debounce(.milliseconds(300), scheduler: MainScheduler.asyncInstance)
     )
   }
 }


### PR DESCRIPTION
### 수정내역 (필수)
- 노트 상세 화면에서 노트 수정화면을 호출 할 때, completionRelay가 누락되어있어 이벤트를 전달받지 못하는 문제를 수정했어요.
- 노트 수정이 완료되면 dismiss로직을 호출하고 completion 클로저에서 이벤트를 전달하도록 수정했어요.
- 노트 상세 Reactor에서 completionRelay에 불필요한 오퍼레이터를 제거했어요.
