### PR TITLE
[Domain] 노트 입력 화면에서 링크 아이템을 삭제할 수 있어요. 그외 SwipeCellConfiguration 기능을 개선했어요.

### DIFF
--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
@@ -433,22 +433,26 @@ extension CreateNoteViewController {
   private func generateEditableSwipeConfigure(at indexPath: IndexPath) -> UISwipeActionsConfiguration? {
     switch dataSource[indexPath] {
       case .stock:
-        let delete = self.deleteCellAction(at: indexPath)
-        
-        let edit = self.editCellAction(at: indexPath)
-        
-        let swipeActionConfig = UISwipeActionsConfiguration(actions: [delete, edit])
-        swipeActionConfig.performsFirstActionWithFullSwipe = false
-        return swipeActionConfig
+        return self.generateSwipeAction(indexPath: indexPath, name: "종목")
+      case .link:
+        return self.generateSwipeAction(indexPath: indexPath, name: "링크")
       default:
         return nil
     }
   }
   
-  private func deleteCellAction(at indexPath: IndexPath) -> UIContextualAction {
+  private func generateSwipeAction(indexPath: IndexPath, name: String) -> UISwipeActionsConfiguration? {
+    let delete = self.deleteCellAction(at: indexPath, name: name)
+    let edit = self.editCellAction(at: indexPath)
+    let swipeActionConfig = UISwipeActionsConfiguration(actions: [delete, edit])
+    swipeActionConfig.performsFirstActionWithFullSwipe = false
+    return swipeActionConfig
+  }
+  
+  private func deleteCellAction(at indexPath: IndexPath, name: String) -> UIContextualAction {
     let action = UIContextualAction(style: .destructive, title: "삭제") { [weak self] _, _, completionHandler in
       
-      let alertController = UIAlertController(title: nil, message: "종목을 삭제하시겠습니까?", preferredStyle: .alert)
+      let alertController = UIAlertController(title: nil, message: "\(name)을(를) 삭제하시겠습니까?", preferredStyle: .alert)
       
       let ok = UIAlertAction(title: "확인", style: .destructive, handler: { _ in
         self?.rxNoteItemDeleteRelay.accept(indexPath)

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
@@ -36,7 +36,7 @@ class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
   
   let rxAddStockDidTapRelay: PublishRelay<Void> = PublishRelay()
   
-  private let rxStockItemDeleteRelay: PublishRelay<IndexPath> = PublishRelay()
+  private let rxNoteItemDeleteRelay: PublishRelay<IndexPath> = PublishRelay()
   
   private let rxStockItemDidEditRelay: PublishRelay<IndexPath> = PublishRelay()
   
@@ -287,8 +287,8 @@ class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
       .bind(to: reactor.action)
       .disposed(by: self.disposeBag)
     
-    rxStockItemDeleteRelay
-      .map { Reactor.Action.stockItemDidDeleted($0) }
+    rxNoteItemDeleteRelay
+      .map { Reactor.Action.noteItemDidDeleted($0) }
       .bind(to: reactor.action)
       .disposed(by: self.disposeBag)
     
@@ -451,7 +451,7 @@ extension CreateNoteViewController {
       let alertController = UIAlertController(title: nil, message: "종목을 삭제하시겠습니까?", preferredStyle: .alert)
       
       let ok = UIAlertAction(title: "확인", style: .destructive, handler: { _ in
-        self?.rxStockItemDeleteRelay.accept(indexPath)
+        self?.rxNoteItemDeleteRelay.accept(indexPath)
       })
       
       let cancel = UIAlertAction(title: "취소", style: .default, handler: nil)

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -75,6 +75,7 @@ final class CreateNoteViewReactor: Reactor {
     case fetchLinkSection(NoteSectionItem)
     case shouldRegisterButtonEnabeld(Bool)
     case stockItemDidDeleted(Int)
+    case linkItemDidDeleted(Int)
     case requestNoteDataDidChanged(NoteRequestDTO)
   }
 
@@ -186,6 +187,8 @@ final class CreateNoteViewReactor: Reactor {
       newState.shouldReigsterButtonEnabled = enabled
     case .stockItemDidDeleted(let row):
       newState.sections[NoteSection.Identity.stock.rawValue].items.remove(at: row)
+    case .linkItemDidDeleted(let row):
+      newState.sections[NoteSection.Identity.link.rawValue].items.remove(at: row)
     case .requestNoteDataDidChanged(let data):
       newState.requestNote = data
     }


### PR DESCRIPTION
### 수정내역 (필수)
- Cell 삭제 SwipeConfiguration을 생성해주는 메소드를 추가했어요.
- 링크 Cell도 Swipe가 가능하게 Delegate 메소드를 수정했어요.
- 노트 입력 화면에서 종목 삭제 이벤트를 전달할 Relay의 이름을 NoteItem으로 변경했어요.
- 노트 입력 Reactor에서 종목 삭제 Action을 아이템 삭제와 관련된 이름으로 변경했어요.
- 노트 링크 SectionItem을 제거해 줄 수 있는 Mutation을 추가했어요.
- 노트 아이템 삭제 Mutation에서는 indexPath를 기반으로 종목과 링크 아이템을 requestNote에서 제거해줘요.

### 스크린샷 (선택사항)
|종목 삭제|링크 삭제|
|-----------------------------|-----------------------------|
|![ezgif com-gif-maker (2)](https://user-images.githubusercontent.com/19662529/151699318-f23403da-b435-497d-af62-a6d886f458d8.gif)|![ezgif com-gif-maker (4)](https://user-images.githubusercontent.com/19662529/151699328-2b9638a0-18ab-459d-9968-d59c96a268ca.gif)|

