### PR TITLE
[Domain] 종목 기록하기 Cell에 아이템 추가 제한 기능을 추가했어요. 그 외 기타 수정

### DIFF
--- a/Tooda/Sources/Common/UIColor+Extension.swift
+++ b/Tooda/Sources/Common/UIColor+Extension.swift
@@ -99,7 +99,7 @@ extension UIColor {
   }
   
   class var gray6: UIColor {
-    return .init(hex: "#383C43")
+    return .init(hex: "#FCFDFE")
   }
   
   class var mainGreen: UIColor {

--- a/Tooda/Sources/Scenes/CreateNote/Cells/EmptyNoteStockCell.swift
+++ b/Tooda/Sources/Scenes/CreateNote/Cells/EmptyNoteStockCell.swift
@@ -23,15 +23,14 @@ class EmptyNoteStockCell: BaseTableViewCell, View {
   var disposeBag: DisposeBag = DisposeBag()
   
   let containerView = UIView().then {
-    $0.layer.borderColor = Constants.baseColor?.cgColor
+    $0.backgroundColor = UIColor.gray6
+    $0.layer.borderColor = UIColor.gray4.cgColor
     $0.layer.borderWidth = 1.0
     $0.layer.masksToBounds = true
   }
   
   let titleLabel = UILabel().then {
-    $0.text = "종목 기록하기"
-    $0.textColor = UIColor(type: .gray2)
-    $0.font = UIFont.systemFont(ofSize: 13, weight: .bold)
+    $0.attributedText = "종목 기록하기".styled(with: TextStyle.body(color: UIColor.gray2))
     $0.sizeToFit()
   }
   

--- a/Tooda/Sources/Scenes/CreateNote/Cells/Reactors/EmptyNoteStockCellReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/Cells/Reactors/EmptyNoteStockCellReactor.swift
@@ -24,7 +24,8 @@ final class EmptyNoteStockCellReactor: Reactor {
   let initialState: State
   private let uuid: String = UUID().uuidString
 
-  init(isEnabled: Bool) {
+  init(itemCount: Int = 0) {
+    let isEnabled = itemCount < EmptyNoteStockCellReactor.itemMaxCount
     initialState = State(isEnabled: isEnabled)
   }
 
@@ -36,6 +37,8 @@ final class EmptyNoteStockCellReactor: Reactor {
     var newState = state
     return newState
   }
+  
+  static let itemMaxCount: Int = 5
 }
 
 extension EmptyNoteStockCellReactor: Hashable {

--- a/Tooda/Sources/Scenes/CreateNote/Cells/Reactors/EmptyNoteStockCellReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/Cells/Reactors/EmptyNoteStockCellReactor.swift
@@ -18,14 +18,14 @@ final class EmptyNoteStockCellReactor: Reactor {
   }
 
   struct State {
-
+    var isEnabled: Bool
   }
 
   let initialState: State
   private let uuid: String = UUID().uuidString
 
-  init() {
-    initialState = State()
+  init(isEnabled: Bool) {
+    initialState = State(isEnabled: isEnabled)
   }
 
   func mutate(action: Action) -> Observable<Mutation> {

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
@@ -63,6 +63,7 @@ class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
         
       cell.rx.didTapAddStock
         .debounce(.milliseconds(500), scheduler: MainScheduler.instance)
+        .filter { reactor.initialState.isEnabled }
         .subscribe(onNext: { [weak self] in
           self?.rxAddStockDidTapRelay.accept($0)
         })

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -95,8 +95,6 @@ final class CreateNoteViewReactor: Reactor {
   
   private let linkItemMaxCount: Int = 2
   
-  static let stockItemMaxCount: Int = 5
-  
   private var lastEditableStockCellIndexPath: IndexPath?
 
   let dependency: Dependency
@@ -560,8 +558,7 @@ extension CreateNoteViewReactor {
 
 extension CreateNoteViewReactor {
   private func emptyStockItemDidChanged(by count: Int) -> Observable<Mutation> {
-    let isEnabeld = count < CreateNoteViewReactor.stockItemMaxCount
-    let reactor = EmptyNoteStockCellReactor(isEnabled: isEnabeld)
+    let reactor = EmptyNoteStockCellReactor(itemCount: count)
     let sectionItem = NoteSectionItem.addStock(reactor)
     return .just(.fetchEmptyStockItem(sectionItem))
   }
@@ -581,7 +578,7 @@ let createDiarySectionFactory: CreateNoteSectionType = { authorization, coordina
   let contentReactor: NoteContentCellReactor = NoteContentCellReactor(payload: .init(title: "", content: ""))
   let contentSectionItem: NoteSectionItem = NoteSectionItem.content(contentReactor)
   
-  let addStockReactor: EmptyNoteStockCellReactor = EmptyNoteStockCellReactor(isEnabled: true)
+  let addStockReactor: EmptyNoteStockCellReactor = EmptyNoteStockCellReactor()
   let addStockSectionItem: NoteSectionItem = NoteSectionItem.addStock(addStockReactor)
   
   let imageReactor: NoteImageCellReactor = NoteImageCellReactor(dependency: .init(factory: noteImageSectionFactory))
@@ -639,9 +636,7 @@ let modifiableNoteSectionFactory: (NoteRequestDTO, LinkPreViewServiceType) -> [N
     sections[NoteSection.Identity.stock.rawValue].items = sectionItems
   }
   
-  let isEnabled = note.stocks.count < CreateNoteViewReactor.stockItemMaxCount
-  
-  let addStockReactor: EmptyNoteStockCellReactor = EmptyNoteStockCellReactor(isEnabled: isEnabled)
+  let addStockReactor: EmptyNoteStockCellReactor = EmptyNoteStockCellReactor(itemCount: note.stocks.count)
   let addStockSectionItem: NoteSectionItem = NoteSectionItem.addStock(addStockReactor)
   
   let imageReactor: NoteImageCellReactor = NoteImageCellReactor(

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -502,7 +502,7 @@ extension CreateNoteViewReactor {
     return Observable.concat([
       .just(.requestNoteDataDidChanged(requestNote)),
       .just(.stockItemDidDeleted(row)),
-      self.emptyStockItemDidChanged(by: requestNote.stocks.count)
+      self.emptyStockItemDidChanged(by: requestNote.stocks.count),
       changedMutation
     ])
   }

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -77,6 +77,7 @@ final class CreateNoteViewReactor: Reactor {
     case stockItemDidDeleted(Int)
     case linkItemDidDeleted(Int)
     case requestNoteDataDidChanged(NoteRequestDTO)
+    case fetchEmptyStockItem(NoteSectionItem)
   }
 
   struct State: Then {
@@ -193,6 +194,8 @@ final class CreateNoteViewReactor: Reactor {
       newState.sections[NoteSection.Identity.link.rawValue].items.remove(at: row)
     case .requestNoteDataDidChanged(let data):
       newState.requestNote = data
+    case .fetchEmptyStockItem(let sectionItem):
+      newState.sections[NoteSection.Identity.addStock.rawValue].items = [sectionItem]
     }
 
     return newState
@@ -549,6 +552,18 @@ extension CreateNoteViewReactor {
     }
     
     return .empty()
+  }
+}
+
+
+// MARK: - Changed EmptyStockItem
+
+extension CreateNoteViewReactor {
+  private func emptyStockItemDidChanged(by count: Int) -> Observable<Mutation> {
+    let isEnabeld = count < CreateNoteViewReactor.stockItemMaxCount
+    let reactor = EmptyNoteStockCellReactor(isEnabled: isEnabeld)
+    let sectionItem = NoteSectionItem.addStock(reactor)
+    return .just(.fetchEmptyStockItem(sectionItem))
   }
 }
 

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -94,6 +94,8 @@ final class CreateNoteViewReactor: Reactor {
   
   private let linkItemMaxCount: Int = 2
   
+  static let stockItemMaxCount: Int = 5
+  
   private var lastEditableStockCellIndexPath: IndexPath?
 
   let dependency: Dependency
@@ -564,7 +566,7 @@ let createDiarySectionFactory: CreateNoteSectionType = { authorization, coordina
   let contentReactor: NoteContentCellReactor = NoteContentCellReactor(payload: .init(title: "", content: ""))
   let contentSectionItem: NoteSectionItem = NoteSectionItem.content(contentReactor)
   
-  let addStockReactor: EmptyNoteStockCellReactor = EmptyNoteStockCellReactor()
+  let addStockReactor: EmptyNoteStockCellReactor = EmptyNoteStockCellReactor(isEnabled: true)
   let addStockSectionItem: NoteSectionItem = NoteSectionItem.addStock(addStockReactor)
   
   let imageReactor: NoteImageCellReactor = NoteImageCellReactor(dependency: .init(factory: noteImageSectionFactory))
@@ -622,7 +624,9 @@ let modifiableNoteSectionFactory: (NoteRequestDTO, LinkPreViewServiceType) -> [N
     sections[NoteSection.Identity.stock.rawValue].items = sectionItems
   }
   
-  let addStockReactor: EmptyNoteStockCellReactor = EmptyNoteStockCellReactor()
+  let isEnabled = note.stocks.count < CreateNoteViewReactor.stockItemMaxCount
+  
+  let addStockReactor: EmptyNoteStockCellReactor = EmptyNoteStockCellReactor(isEnabled: isEnabled)
   let addStockSectionItem: NoteSectionItem = NoteSectionItem.addStock(addStockReactor)
   
   let imageReactor: NoteImageCellReactor = NoteImageCellReactor(

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -334,7 +334,8 @@ extension CreateNoteViewReactor {
     
     return .concat([
       .just(.requestNoteDataDidChanged(requestNote)),
-      .just(.fetchStockSection(sectionItem))
+      .just(.fetchStockSection(sectionItem)),
+      self.emptyStockItemDidChanged(by: requestNote.stocks.count)
     ])
   }
   
@@ -500,6 +501,8 @@ extension CreateNoteViewReactor {
     
     return Observable.concat([
       .just(.requestNoteDataDidChanged(requestNote)),
+      .just(.stockItemDidDeleted(row)),
+      self.emptyStockItemDidChanged(by: requestNote.stocks.count)
       changedMutation
     ])
   }


### PR DESCRIPTION
### 수정내역 (필수)
- gray6 color가 figma 값과 다른 문제를 수정했어요.
- 종목 기록하기 Cell의 Color를 변경하고 titleLabel에 textStyle을 적용했어요.
- 종목 기록하기 Cell Reactor에 State에 활성화 여부를 표현하는 프로퍼티를 추가했어요. 프로퍼티가 추가됨에 따라 SectionFactory의 코드도 수정했어요. IsEnabeld 값은 종목 갯수를 비교하여 초기화 해요.
- 종목 기록하기 Cell Reactor의 axCount를 표현하는 static 프로퍼티를 추가했어요.
- 종목 기록하기 SectionItem을 새로 그려줄 Mutation을 추가하고 메소드를 구현했어요.
- 종목 아이템 Cell의 Add / Delete Mutation 메소드 내부에서 stock 상태에 따라 다른 SectionItem을 그려주도록 로직을 추가했어요.
- 노트 입력 화면에서 DataSource 클로저 내부에 종목 기록하기 Cell Tap 이벤트에 필터링 오퍼레이터를 추가했어요.

### 스크린샷 (선택사항)
![ezgif com-gif-maker (5)](https://user-images.githubusercontent.com/19662529/151702204-02040054-914b-4243-9feb-8098a0c1b410.gif)
