### PR TITLE
[Domain] 노트 등록/수정 화면에 Global Event에 대한 의존성을 추가하고, 등록/수정 이후에 이벤트를 전달해요.

### DIFF
--- a/Tooda/Sources/Core/AppFactory.swift
+++ b/Tooda/Sources/Core/AppFactory.swift
@@ -49,7 +49,8 @@ final class AppFactory: AppFactoryType {
           linkPreviewService:
             self.dependency.appInject.resolve(LinkPreViewServiceType.self),
           createDiarySectionFactory: createDiarySectionFactory,
-          modifiableNoteSectionFactory: nil
+          modifiableNoteSectionFactory: nil,
+          noteEventBus: NoteEventBus.event
         ),
         modifiableNote: nil,
         payload: .init(updateCompletionRelay: nil)
@@ -69,7 +70,8 @@ final class AppFactory: AppFactoryType {
             linkPreviewService:
               self.dependency.appInject.resolve(LinkPreViewServiceType.self),
             createDiarySectionFactory: nil,
-            modifiableNoteSectionFactory: modifiableNoteSectionFactory
+            modifiableNoteSectionFactory: modifiableNoteSectionFactory,
+            noteEventBus: NoteEventBus.event
           ),
           modifiableNote: note,
           payload: .init(updateCompletionRelay: updateCompletionRelay)

--- a/Tooda/Sources/Core/AppFactory.swift
+++ b/Tooda/Sources/Core/AppFactory.swift
@@ -52,8 +52,7 @@ final class AppFactory: AppFactoryType {
           modifiableNoteSectionFactory: nil,
           noteEventBus: NoteEventBus.event
         ),
-        modifiableNote: nil,
-        payload: .init(updateCompletionRelay: nil)
+        modifiableNote: nil
       )
         
       let viewController = CreateNoteViewController(dateString: today, reactor: reactor, mode: .add)
@@ -61,7 +60,7 @@ final class AppFactory: AppFactoryType {
       navigationController.modalPresentationStyle = .overFullScreen
       return navigationController
         
-    case .modifyNote(let dateString, let note, let updateCompletionRelay):
+    case .modifyNote(let dateString, let note):
         let reactor = CreateNoteViewReactor(
           dependency: .init(
             service: self.dependency.appInject.resolve(NetworkingProtocol.self),
@@ -73,8 +72,7 @@ final class AppFactory: AppFactoryType {
             modifiableNoteSectionFactory: modifiableNoteSectionFactory,
             noteEventBus: NoteEventBus.event
           ),
-          modifiableNote: note,
-          payload: .init(updateCompletionRelay: updateCompletionRelay)
+          modifiableNote: note
         )
         
         let viewController = CreateNoteViewController(dateString: dateString, reactor: reactor, mode: .update)

--- a/Tooda/Sources/Core/Coordinator/Scene.swift
+++ b/Tooda/Sources/Core/Coordinator/Scene.swift
@@ -16,7 +16,7 @@ enum Scene {
   case login
   case home
   case createNote(dateString: String)
-  case modifyNote(dateString: String, note: NoteRequestDTO, updateCompletonRelay: PublishRelay<Note>?)
+  case modifyNote(dateString: String, note: NoteRequestDTO)
   case settings
   case addStock(completion: PublishRelay<NoteStock>)
   case search

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -72,6 +72,7 @@ final class CreateNoteViewReactor: Reactor {
     var requestNote: NoteRequestDTO = NoteRequestDTO()
   }
   
+  // FIXME: Global Event 추가로 제거 예정이에요.
   struct Payload {
     var updateCompletionRelay: PublishRelay<Note>?
   }
@@ -413,12 +414,13 @@ self.dependency.coordinator.transition(
     
     guard "\(note.id)".isNotEmpty else { return .empty() }
     
+    self.dependency.noteEventBus.onNext(.createNote(note))
+    
     self.dependency.coordinator.close(
       style: .dismiss,
       animated: true,
       completion: { [weak self] in
         self?.payload.updateCompletionRelay?.accept(note)
-        self?.dependency.noteEventBus.onNext(.createNote(note))
       }
     )
     
@@ -463,12 +465,13 @@ extension CreateNoteViewReactor {
     
     guard "\(note.id)".isNotEmpty else { return .empty() }
     
+    self.dependency.noteEventBus.onNext(.editNode(note))
+    
     self.dependency.coordinator.close(
       style: .dismiss,
       animated: true,
       completion: { [weak self] in
         self?.payload.updateCompletionRelay?.accept(note)
-        self?.dependency.noteEventBus.onNext(.editNode(note))
       }
     )
     

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -71,11 +71,6 @@ final class CreateNoteViewReactor: Reactor {
     var shouldReigsterButtonEnabled: Bool = false
     var requestNote: NoteRequestDTO = NoteRequestDTO()
   }
-  
-  // FIXME: Global Event 추가로 제거 예정이에요.
-  struct Payload {
-    var updateCompletionRelay: PublishRelay<Note>?
-  }
 
   let initialState: State
   
@@ -84,8 +79,6 @@ final class CreateNoteViewReactor: Reactor {
   private var lastEditableStockCellIndexPath: IndexPath?
 
   let dependency: Dependency
-  
-  private let payload: Payload
   
   // MARK: Global Events
   
@@ -96,7 +89,7 @@ final class CreateNoteViewReactor: Reactor {
   
   private let stockItemEditCompletionRelay: PublishRelay<NoteStock> = PublishRelay()
   
-  init(dependency: Dependency, modifiableNote: NoteRequestDTO?, payload: Payload) {
+  init(dependency: Dependency, modifiableNote: NoteRequestDTO?) {
     self.dependency = dependency
     
     if let requestNote = modifiableNote {
@@ -104,8 +97,6 @@ final class CreateNoteViewReactor: Reactor {
     } else {
       self.initialState = State()
     }
-    
-    self.payload = payload
   }
 
   func mutate(action: Action) -> Observable<Mutation> {
@@ -419,9 +410,7 @@ self.dependency.coordinator.transition(
     self.dependency.coordinator.close(
       style: .dismiss,
       animated: true,
-      completion: { [weak self] in
-        self?.payload.updateCompletionRelay?.accept(note)
-      }
+      completion: nil
     )
     
     return .empty()
@@ -470,9 +459,7 @@ extension CreateNoteViewReactor {
     self.dependency.coordinator.close(
       style: .dismiss,
       animated: true,
-      completion: { [weak self] in
-        self?.payload.updateCompletionRelay?.accept(note)
-      }
+      completion: nil
     )
     
     return .empty()

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -418,6 +418,7 @@ self.dependency.coordinator.transition(
       animated: true,
       completion: { [weak self] in
         self?.payload.updateCompletionRelay?.accept(note)
+        self?.dependency.noteEventBus.onNext(.createNote(note))
       }
     )
     

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -29,22 +29,7 @@ final class CreateNoteViewReactor: Reactor {
     let linkPreviewService: LinkPreViewServiceType
     let createDiarySectionFactory: CreateNoteSectionType?
     let modifiableNoteSectionFactory: ModifiableNoteSectionType?
-    
-    init(
-      service: NetworkingProtocol,
-      coordinator: AppCoordinatorType,
-      authorization: AppAuthorizationType,
-      linkPreviewService: LinkPreViewServiceType,
-      createDiarySectionFactory: CreateNoteSectionType?,
-      modifiableNoteSectionFactory: ModifiableNoteSectionType?
-    ) {
-      self.service = service
-      self.coordinator = coordinator
-      self.authorization = authorization
-      self.linkPreviewService = linkPreviewService
-      self.createDiarySectionFactory = createDiarySectionFactory
-      self.modifiableNoteSectionFactory = modifiableNoteSectionFactory
-    }
+    let noteEventBus: PublishSubject<NoteEventBus.Event>
   }
 
   enum Action {

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -452,6 +452,7 @@ extension CreateNoteViewReactor {
       animated: true,
       completion: { [weak self] in
         self?.payload.updateCompletionRelay?.accept(note)
+        self?.dependency.noteEventBus.onNext(.editNode(note))
       }
     )
     

--- a/Tooda/Sources/Scenes/NoteDetail/NoteDetailReactor.swift
+++ b/Tooda/Sources/Scenes/NoteDetail/NoteDetailReactor.swift
@@ -53,8 +53,6 @@ final class NoteDetailReactor: Reactor {
   // MARK: Properties
 
   private let dependency: Dependency
-  
-  private let noteUpdateCompletionRelay: PublishRelay<Note> = PublishRelay()
 
   let initialState: State
 
@@ -62,14 +60,6 @@ final class NoteDetailReactor: Reactor {
     self.dependency = dependency
     self.initialState =
       State.generateInitialState(noteID: dependency.payload.id)
-  }
-  
-  func transform(action: Observable<Action>) -> Observable<Action> {
-    return Observable.merge(
-      action,
-      self.noteUpdateCompletionRelay
-        .map { _ in Action.loadData }
-    )
   }
 }
 
@@ -155,8 +145,7 @@ extension NoteDetailReactor {
     let dateString = note.createdAt?.string(.dot) ?? ""
     
     self.dependency.coordinator.transition(to: .modifyNote(dateString: dateString,
-                                                           note: noteRequestDTO,
-                                                           updateCompletonRelay: self.noteUpdateCompletionRelay),
+                                                           note: noteRequestDTO),
                                            using: .modal, animated: true, completion: nil)
   }
 }


### PR DESCRIPTION
### 수정내역 (필수)
- 노트 등록/수정 Reactor Dependency에 NoteEventBus에 대한 PublishSubject 프로퍼티를 추가했어요.
- 노트 등록이 완료되면 화면을 내리고 Completion을 수행할 메소드를 추가했어요.
- 노트 등록/수정 Completion 메소드에서 dismiss completion에 Global Event를 방출하는 로직을 추가했어요.
