### PR TITLE
[Domain] 노트 상세 화면에서 이미지 아이템을 볼 수 있어요.

### DIFF
--- a/Tooda/Sources/Common/Extensions/UIImage+Extension.swift
+++ b/Tooda/Sources/Common/Extensions/UIImage+Extension.swift
@@ -1,0 +1,23 @@
+//
+//  UIImage+Extension.swift
+//  Tooda
+//
+//  Created by Lyine on 2022/02/02.
+//
+
+import UIKit
+
+extension UIImage {
+  // 이미지의 사이즈를 width 비율에 맞게 변경
+  func resizeImage(width: CGFloat) -> UIImage {
+    let scale = width / self.size.width
+    let newHeight = self.size.height * scale
+    UIGraphicsBeginImageContextWithOptions(CGSize(width: width, height: newHeight), false, 0)
+    self.draw(in: CGRect(x: 0, y: 0, width: width, height: newHeight))
+    let newImage = UIGraphicsGetImageFromCurrentImageContext()
+    UIGraphicsEndImageContext()
+    
+    guard let newSizeImage = newImage else { return UIImage() }
+    return newSizeImage
+  }
+}

--- a/Tooda/Sources/Scenes/NoteDetail/Cells/NoteDetailImageCell.swift
+++ b/Tooda/Sources/Scenes/NoteDetail/Cells/NoteDetailImageCell.swift
@@ -1,0 +1,53 @@
+//
+//  NoteDetailImageCell.swift
+//  Tooda
+//
+//  Created by Lyine on 2022/02/01.
+//
+
+import UIKit
+import SnapKit
+
+final class NoteDetailImageCell: BaseTableViewCell {
+  
+  enum Metric {
+    static let margin: CGFloat = 20.0
+  }
+  
+  // MARK: - UI Properties
+  
+  private let imageContainerView = UIImageView().then {
+    $0.contentMode = .scaleAspectFill
+    $0.backgroundColor = UIColor.gray6
+    $0.clipsToBounds = true
+  }
+  
+  private let indicatorView = UIActivityIndicatorView()
+  
+  override func configureUI() {
+    super.configureUI()
+    
+    contentView.addSubviews(
+      imageContainerView,
+      indicatorView
+    )
+  }
+  
+  func configure(data: Data) {
+    super.configure()
+  }
+  
+  override func setupConstraints() {
+    super.setupConstraints()
+    
+    imageContainerView.snp.makeConstraints {
+      $0.top.equalToSuperview().offset(Metric.margin)
+      $0.leading.trailing.equalToSuperview().inset(Metric.margin)
+      $0.bottom.equalToSuperview()
+    }
+    
+    indicatorView.snp.makeConstraints {
+      $0.edges.equalToSuperview()
+    }
+  }
+}

--- a/Tooda/Sources/Scenes/NoteDetail/Cells/NoteDetailImageCell.swift
+++ b/Tooda/Sources/Scenes/NoteDetail/Cells/NoteDetailImageCell.swift
@@ -35,6 +35,17 @@ final class NoteDetailImageCell: BaseTableViewCell {
   
   func configure(data: Data) {
     super.configure()
+    
+    self.indicatorView.startAnimating()
+    
+    DispatchQueue.global(qos: .background).async {
+      guard let image = UIImage(data: data) else { return }
+      
+      DispatchQueue.main.async { [weak self] in
+        self?.imageContainerView.image = image
+        self?.indicatorView.stopAnimating()
+      }
+    }
   }
   
   override func setupConstraints() {

--- a/Tooda/Sources/Scenes/NoteDetail/NoteDetailReactor.swift
+++ b/Tooda/Sources/Scenes/NoteDetail/NoteDetailReactor.swift
@@ -139,6 +139,22 @@ extension NoteDetailReactor {
       }
   }
   
+  private func loadImageMutation(images: [NoteImage]) -> Observable<Mutation> {
+    return Observable.create { observer in
+      DispatchQueue.global(qos: .background).async {
+        let imageSectionItems = images
+          .compactMap { URL(string: $0.imageURL) }
+          .compactMap { try? Data(contentsOf: $0) }
+          .map { NoteDetailSectionItem.image($0) }
+        
+        observer.onNext(.appendImageSection(imageSectionItems))
+        observer.onCompleted()
+      }
+      
+      return Disposables.create()
+    }
+  }
+  
   private func editNote() {
     guard let note = self.currentState.note else { return }
     

--- a/Tooda/Sources/Scenes/NoteDetail/NoteDetailViewController.swift
+++ b/Tooda/Sources/Scenes/NoteDetail/NoteDetailViewController.swift
@@ -130,6 +130,8 @@ final class NoteDetailViewController: BaseViewController<NoteDetailReactor> {
   // MARK: Bind
 
   override func bind(reactor: NoteDetailReactor) {
+    
+    self.tableView.rx.setDelegate(self).disposed(by: self.disposeBag)
 
     // Action
     self.rx.viewDidLoad
@@ -202,4 +204,21 @@ final class NoteDetailViewController: BaseViewController<NoteDetailReactor> {
 
   }
   
+}
+
+// MARK: - Extensions
+
+extension NoteDetailViewController: UITableViewDelegate {
+  func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+    switch dataSource[indexPath] {
+      case .title, .content, .link, .sticker, .stock:
+        return UITableView.automaticDimension
+      case .image(let data):
+        guard let image = UIImage(data: data) else { return UITableView.automaticDimension }
+        
+        let resizedImage = image.resizeImage(width: tableView.frame.width - NoteDetailImageCell.Metric.margin - NoteDetailImageCell.Metric.margin)
+        
+        return NoteDetailImageCell.Metric.margin + resizedImage.size.height
+    }
+  }
 }

--- a/Tooda/Sources/Scenes/NoteDetail/NoteDetailViewController.swift
+++ b/Tooda/Sources/Scenes/NoteDetail/NoteDetailViewController.swift
@@ -80,7 +80,6 @@ final class NoteDetailViewController: BaseViewController<NoteDetailReactor> {
   private let tableView = UITableView().then {
     $0.separatorStyle = .none
     $0.backgroundColor = .white
-    $0.rowHeight = UITableView.automaticDimension
     $0.alwaysBounceHorizontal = false
     $0.allowsSelection = false
     $0.register(UITableViewCell.self)

--- a/Tooda/Sources/Scenes/NoteDetail/NoteDetailViewController.swift
+++ b/Tooda/Sources/Scenes/NoteDetail/NoteDetailViewController.swift
@@ -155,6 +155,7 @@ final class NoteDetailViewController: BaseViewController<NoteDetailReactor> {
       .disposed(by: self.disposeBag)
     
     reactor.state
+      .observe(on: MainScheduler.asyncInstance)
       .map { $0.sectionModel }
       .bind(to: tableView.rx.items(dataSource: dataSource))
       .disposed(by: disposeBag)

--- a/Tooda/Sources/Scenes/NoteDetail/NoteDetailViewController.swift
+++ b/Tooda/Sources/Scenes/NoteDetail/NoteDetailViewController.swift
@@ -45,6 +45,13 @@ final class NoteDetailViewController: BaseViewController<NoteDetailReactor> {
       
       return UITableViewCell()
     case .image:
+      
+      if case let .image(data) = item {
+        let cell = tableView.dequeue(NoteDetailImageCell.self, indexPath: indexPath)
+        cell.configure(data: data)
+        return cell
+      }
+      
       return UITableViewCell()
     case .link:
         if case let .link(reactor) = item {
@@ -73,16 +80,16 @@ final class NoteDetailViewController: BaseViewController<NoteDetailReactor> {
   private let tableView = UITableView().then {
     $0.separatorStyle = .none
     $0.backgroundColor = .white
-    $0.estimatedRowHeight = UITableView.automaticDimension
+    $0.rowHeight = UITableView.automaticDimension
     $0.alwaysBounceHorizontal = false
     $0.allowsSelection = false
-    $0.estimatedRowHeight = UITableView.automaticDimension
     $0.register(UITableViewCell.self)
     $0.register(NoteStickerCell.self)
     $0.register(NoteDetailTitleCell.self)
     $0.register(NoteDetailTextContentCell.self)
     $0.register(NoteStockCell.self)
     $0.register(NoteLinkCell.self)
+    $0.register(NoteDetailImageCell.self)
   }
   
   private let moreDetailButton = UIBarButtonItem().then {

--- a/Tooda/Sources/Scenes/NoteDetail/Section/NoteDetailSection.swift
+++ b/Tooda/Sources/Scenes/NoteDetail/Section/NoteDetailSection.swift
@@ -29,6 +29,6 @@ enum NoteDetailSectionItem {
   case title(String, Date?)
   case content(String)
   case stock(NoteStockCellReactor)
-  case image(String)
+  case image(Data)
   case link(NoteLinkCellReactor)
 }

--- a/Tooda/Sources/Scenes/NoteList/NoteListReactor.swift
+++ b/Tooda/Sources/Scenes/NoteList/NoteListReactor.swift
@@ -183,7 +183,7 @@ extension NoteListReactor {
         month: initialState.dateInfo.month
         )
       )
-      .map(NoteListDTO.self)
+      .toodaMap(NoteListDTO.self)
       .catchAndReturn(NoteListDTO(cursor: nil, noteList: []))
       .asObservable()
       .flatMap { noteDTO -> Observable<Mutation> in
@@ -232,7 +232,7 @@ extension NoteListReactor {
         month: dependency.payload.month
         )
       )
-      .map(NoteListDTO.self)
+      .toodaMap(NoteListDTO.self)
       .asObservable()
       .flatMap { noteDTO -> Observable<Mutation> in
         guard let noteList = noteDTO.noteList else {


### PR DESCRIPTION
### 수정내역 (필수)
- UIImage를 특정 width 비율로 계산된 사이즈의 이미지로 변환하는 Extension 메소드를 추가했어요.
- 노트 리스트 Reactor에서 NoteListDTO를 매핑할 때 쓰는 .map 오퍼레이터를 변경했어요.
- 노트 상세 DetailImageCell을 추가했어요.
- 노트 상세 SectionItem에서 Image case의 연관값의 타입을 String에서 Data로 변경했어요.
- 노트 상세 Reactor에서 이미지 Section을 만들어주기위한 Mutation 메소드와 case를 정의했어요.
- 노트 상세 Reactor에서 SectionModel을 만들 때 스트림간의 Scheduler를 변경했어요.
- 노트 상세 ViewController에 UITableViewDelegate를 채택하고, heightForAt 메소드를 구현했어요. 그로인해 tableView의 불필요한 프로퍼티를 제거하게 되었어요.

### 스크린샷 (선택사항)
![ezgif com-gif-maker (6)](https://user-images.githubusercontent.com/19662529/152074958-33968fa8-5337-4ca6-b5c3-834cb82e2025.gif)

