### PR TITLE
[Domain] 노트 등록/수정 화면에 짜잘한 예외처리를 구현했어요.

### DIFF
--- a/Tooda/Sources/Scenes/CreateNote/Cells/EmptyNoteImageItemCell.swift
+++ b/Tooda/Sources/Scenes/CreateNote/Cells/EmptyNoteImageItemCell.swift
@@ -13,9 +13,7 @@ import ReactorKit
 import SnapKit
 import RxCocoa
 
-class EmptyNoteImageItemCell: BaseCollectionViewCell, View {
-  typealias Reactor = EmptyNoteImageItemCellReactor
-  
+class EmptyNoteImageItemCell: BaseCollectionViewCell {
   var disposeBag: DisposeBag = DisposeBag()
   
   let containerView = UIView().then {
@@ -25,15 +23,6 @@ class EmptyNoteImageItemCell: BaseCollectionViewCell, View {
   }
   
   let addImageButton = UIButton()
-  
-  func configure(reactor: Reactor) {
-    super.configure()
-    self.reactor = reactor
-  }
-  
-  func bind(reactor: Reactor) {
-    
-  }
   
   // MARK: Cell Life Cycle
   

--- a/Tooda/Sources/Scenes/CreateNote/Cells/NoteImageCell.swift
+++ b/Tooda/Sources/Scenes/CreateNote/Cells/NoteImageCell.swift
@@ -98,7 +98,7 @@ class NoteImageCell: BaseTableViewCell, View {
     collectionView.snp.makeConstraints {
       $0.top.equalToSuperview().offset(10)
       $0.leading.trailing.equalToSuperview().inset(20)
-      $0.bottom.equalToSuperview()
+      $0.bottom.equalToSuperview().offset(-60)
       $0.height.equalTo(Constants.baseItemValue)
     }
   }

--- a/Tooda/Sources/Scenes/CreateNote/Cells/NoteImageCell.swift
+++ b/Tooda/Sources/Scenes/CreateNote/Cells/NoteImageCell.swift
@@ -28,7 +28,7 @@ class NoteImageCell: BaseTableViewCell, View {
     switch item {
       case .empty(let reactor):
         let cell = collectionView.dequeue(EmptyNoteImageItemCell.self, indexPath: indexPath)
-        cell.configure(reactor: reactor)
+        cell.configure()
         
         if let relay = self?.cellItemDidTapRelay {
           cell.rx.addImageButtonDidTap

--- a/Tooda/Sources/Scenes/CreateNote/Cells/Reactors/EmptyNoteStockCellReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/Cells/Reactors/EmptyNoteStockCellReactor.swift
@@ -8,6 +8,7 @@
 
 import ReactorKit
 
+@available(*, deprecated, message: "종목 기록하기 Cell의 Reactor는 곧 제거될 예정이에요.")
 final class EmptyNoteStockCellReactor: Reactor {
   enum Action {
 

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
@@ -57,13 +57,12 @@ class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
         .disposed(by: cell.disposeBag)
         
       return cell
-    case .addStock(let reactor):
+    case .addStock:
       let cell = tableView.dequeue(EmptyNoteStockCell.self, indexPath: indexPath)
-      cell.configure(reactor: reactor)
+      cell.configure()
         
       cell.rx.didTapAddStock
         .debounce(.milliseconds(500), scheduler: MainScheduler.instance)
-        .filter { reactor.initialState.isEnabled }
         .subscribe(onNext: { [weak self] in
           self?.rxAddStockDidTapRelay.accept($0)
         })

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -379,7 +379,15 @@ extension CreateNoteViewReactor {
 extension CreateNoteViewReactor {
   private func linkButtonDidTapped() -> Observable<Mutation> {
     
-    self.dependency.coordinator.transition(to: .popUp(type: .textInput(self.addLinkURLCompletionRelay)), using: .modal, animated: false)
+    let maxItemCount: Int = 2
+    
+    if self.currentState.sections[NoteSection.Identity.link.rawValue].items.count < maxItemCount {
+      self.dependency.coordinator.transition(to: .popUp(type: .textInput(self.addLinkURLCompletionRelay)),
+                                             using: .modal,
+                                             animated: false)
+    } else {
+      return .just(.present(.showAlert("링크는 최대 \(maxItemCount)개까지 등록 가능합니다.")))
+    }
     
     return .empty()
   }

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -509,7 +509,6 @@ extension CreateNoteViewReactor {
     
     return Observable.concat([
       .just(.requestNoteDataDidChanged(requestNote)),
-      .just(.stockItemDidDeleted(row)),
       self.emptyStockItemDidChanged(by: requestNote.stocks.count),
       changedMutation
     ])

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -575,9 +575,7 @@ extension CreateNoteViewReactor {
     var sectionItems: [NoteSectionItem] = []
     
     if count < itemMaxCount {
-      let reactor = EmptyNoteStockCellReactor(itemCount: count)
-      let sectionItem = NoteSectionItem.addStock(reactor)
-      sectionItems.append(sectionItem)
+      sectionItems.append(NoteSectionItem.addStock)
     }
     
     return .just(.fetchEmptyStockItem(sectionItems))
@@ -599,7 +597,7 @@ let createDiarySectionFactory: CreateNoteSectionType = { authorization, coordina
   let contentSectionItem: NoteSectionItem = NoteSectionItem.content(contentReactor)
   
   let addStockReactor: EmptyNoteStockCellReactor = EmptyNoteStockCellReactor()
-  let addStockSectionItem: NoteSectionItem = NoteSectionItem.addStock(addStockReactor)
+  let addStockSectionItem: NoteSectionItem = NoteSectionItem.addStock
   
   let imageReactor: NoteImageCellReactor = NoteImageCellReactor(dependency: .init(factory: noteImageSectionFactory))
   let imageSectionItem: NoteSectionItem = NoteSectionItem.image(imageReactor)
@@ -657,7 +655,7 @@ let modifiableNoteSectionFactory: (NoteRequestDTO, LinkPreViewServiceType) -> [N
   }
   
   let addStockReactor: EmptyNoteStockCellReactor = EmptyNoteStockCellReactor(itemCount: note.stocks.count)
-  let addStockSectionItem: NoteSectionItem = NoteSectionItem.addStock(addStockReactor)
+  let addStockSectionItem: NoteSectionItem = NoteSectionItem.addStock
   
   let imageReactor: NoteImageCellReactor = NoteImageCellReactor(
     dependency: .init(

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -77,7 +77,7 @@ final class CreateNoteViewReactor: Reactor {
     case stockItemDidDeleted(Int)
     case linkItemDidDeleted(Int)
     case requestNoteDataDidChanged(NoteRequestDTO)
-    case fetchEmptyStockItem(NoteSectionItem)
+    case fetchEmptyStockItem([NoteSectionItem])
   }
 
   struct State: Then {
@@ -192,8 +192,8 @@ final class CreateNoteViewReactor: Reactor {
       newState.sections[NoteSection.Identity.link.rawValue].items.remove(at: row)
     case .requestNoteDataDidChanged(let data):
       newState.requestNote = data
-    case .fetchEmptyStockItem(let sectionItem):
-      newState.sections[NoteSection.Identity.addStock.rawValue].items = [sectionItem]
+    case .fetchEmptyStockItem(let sectionItems):
+      newState.sections[NoteSection.Identity.addStock.rawValue].items = sectionItems
     }
 
     return newState
@@ -569,9 +569,18 @@ extension CreateNoteViewReactor {
 
 extension CreateNoteViewReactor {
   private func emptyStockItemDidChanged(by count: Int) -> Observable<Mutation> {
-    let reactor = EmptyNoteStockCellReactor(itemCount: count)
-    let sectionItem = NoteSectionItem.addStock(reactor)
-    return .just(.fetchEmptyStockItem(sectionItem))
+    
+    let itemMaxCount = 5
+    
+    var sectionItems: [NoteSectionItem] = []
+    
+    if count < itemMaxCount {
+      let reactor = EmptyNoteStockCellReactor(itemCount: count)
+      let sectionItem = NoteSectionItem.addStock(reactor)
+      sectionItems.append(sectionItem)
+    }
+    
+    return .just(.fetchEmptyStockItem(sectionItems))
   }
 }
 

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -93,8 +93,6 @@ final class CreateNoteViewReactor: Reactor {
 
   let initialState: State
   
-  private let linkItemMaxCount: Int = 2
-  
   private var lastEditableStockCellIndexPath: IndexPath?
 
   let dependency: Dependency
@@ -205,7 +203,6 @@ final class CreateNoteViewReactor: Reactor {
       self.addStockCompletionRelay
         .map { Action.stockItemDidAdded($0) },
       self.addLinkURLCompletionRelay
-        .take(self.linkItemMaxCount)
         .map { Action.linkURLDidAdded($0) },
       self.addStickerCompletionRelay
         .map { Action.stckerDidPicked($0) },

--- a/Tooda/Sources/Scenes/CreateNote/Section/NoteSection.swift
+++ b/Tooda/Sources/Scenes/CreateNote/Section/NoteSection.swift
@@ -28,7 +28,7 @@ extension NoteSection: AnimatableSectionModelType {
 
 enum NoteSectionItem: Hashable {
   case content(NoteContentCellReactor)
-  case addStock(EmptyNoteStockCellReactor)
+  case addStock
   case stock(NoteStockCellReactor)
   case image(NoteImageCellReactor)
   case link(NoteLinkCellReactor)


### PR DESCRIPTION
### 수정내역 (필수)
- 링크 버튼을 눌렀을 때, 현재 Section의 아이템 갯수에따라 유저에게 Alert을 노출해줘요.
- 종목 아이템이 추가되었을 때, 현재 Stock Section의 아이템 갯수에 따라 종목 기록하기 SectionItem을 노출해주는 로직을 추가했어요. Mutation case의 연관값도 변경되었어요.
- 링크 아이템이 삭제될 때, 종목 아이템 삭제 Mutation을 같이 방출해서 크래시가 발생하는 문제를 수정했어요.
- 노트 Section에서 종목 기록하기 SectionItem case에서 불필요한 Reactor 연관값을 제거했어요. 연관값이 제거됨에 따라 SectionItem을 사용하는 부분들의 코드 수정이 발생했어요.
- 노트 컨텐츠가 많아졌을 때, 최하단의 이미지 셀까지 스크롤을 할 수가 없어, 이미지 셀 제약조건을 변경해 스크롤이 가능하게끔 변경했어요.

### 스크린샷 (선택사항)
|링크 아이템 추가/삭제시|
|--------------------------------|
|![링크아이템](https://user-images.githubusercontent.com/19662529/152099872-5b958fe6-bb0f-4a3e-93e6-31ea75dfc821.gif)|

|종목 아이템 추가/삭제시|
|--------------------------------|
|![종목아이템](https://user-images.githubusercontent.com/19662529/152099902-3b67e886-3ca1-4ee7-9b5d-dcce47c58f72.gif)|


|이미지 영역 변경 전|이미지 영역 변경 후|
|--------------------------------|--------------------------------|
|![이미지변경전](https://user-images.githubusercontent.com/19662529/152099925-c28d3ac6-849a-4dc5-b689-b0c05913915b.gif)|![이미지변경후](https://user-images.githubusercontent.com/19662529/152099962-24cb7233-9228-4a5c-bc6c-578b9d80d3fe.gif)|