### PR TITLE
[Domain] 카메라 권한 관련 기능을 추가하고 이미지 추가 액션시트 기능을 변경했어요.

### DIFF
--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
@@ -329,7 +329,7 @@ class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
     
     reactor.state
       .compactMap { $0.presentType }
-      .asDriver(onErrorJustReturn: .showPhotoPicker)
+      .asDriver(onErrorJustReturn: .showImageSourceActionSheetView)
       .drive(onNext: { [weak self] in
         self?.present(by: $0)
       }).disposed(by: self.disposeBag)
@@ -372,8 +372,9 @@ extension CreateNoteViewController {
         self.showAlert(message: message)
       case .showPermission(let message):
         self.showAlertAndOpenAppSetting(message: message)
-      case .showPhotoPicker:
-        self.showPhotoPicker()
+      case .showImageSourceActionSheetView:
+        self.showImageActonSheetView()
+      case .showImagePickerView(let pickerType):
     }
   }
   
@@ -400,7 +401,7 @@ extension CreateNoteViewController {
     self.present(alertController, animated: true, completion: nil)
   }
   
-  private func showPhotoPicker() {
+  private func showImageActonSheetView() {
     let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
     
     let cancel = UIAlertAction(title: "취소", style: .cancel, handler: nil)

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
@@ -14,6 +14,22 @@ import RxDataSources
 import ReactorKit
 import SnapKit
 
+enum ImagePickerType {
+  case photo
+  case camera
+}
+
+extension UIImagePickerController.SourceType {
+  var soureType: ImagePickerType {
+    switch self {
+      case .camera:
+        return .camera
+      case .photoLibrary, .savedPhotosAlbum:
+        return .photo
+    }
+  }
+}
+
 // TODO: 노트 등록이 아닌 입력과 관련된 이름으로 변경해요.
 class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
   typealias Reactor = CreateNoteViewReactor

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
@@ -375,6 +375,16 @@ extension CreateNoteViewController {
       case .showImageSourceActionSheetView:
         self.showImageActonSheetView()
       case .showImagePickerView(let pickerType):
+        self.showImagePickerView(by: pickerType)
+    }
+  }
+  
+  private func showImagePickerView(by pickerType: ImagePickerType) {
+    switch pickerType {
+      case .photo:
+        self.showPickView(by: .photoLibrary)
+      case .camera:
+        self.showPickView(by: .camera)
     }
   }
   

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
@@ -58,7 +58,7 @@ class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
   
   private let rxCombinedTextDidChangedRelay: PublishRelay<(title: String, content: String)> = PublishRelay()
   
-  private let rxImagePickedTypeRleay: PublishRelay<UIImagePickerController.SourceType> = PublishRelay()
+  private let rxImagePickedTypeRelay: PublishRelay<UIImagePickerController.SourceType> = PublishRelay()
   
   // MARK: Properties
   lazy var dataSource: Section = Section(configureCell: { [weak self] _, tableView, indexPath, item -> UITableViewCell in
@@ -305,7 +305,7 @@ class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
       .bind(to: reactor.action)
       .disposed(by: self.disposeBag)
     
-    rxImagePickedTypeRleay
+    rxImagePickedTypeRelay
       .map { $0.soureType }
       .map { Reactor.Action.imagePickerDidTapped($0) }
       .bind(to: reactor.action)
@@ -416,10 +416,10 @@ extension CreateNoteViewController {
     
     let cancel = UIAlertAction(title: "취소", style: .cancel, handler: nil)
     let camera = UIAlertAction(title: "카메라", style: .default) { [weak self] _ in
-      self?.rxImagePickedTypeRleay.accept(.camera)
+      self?.rxImagePickedTypeRelay.accept(.camera)
     }
     let album = UIAlertAction(title: "앨범", style: .default) { [weak self] _ in
-      self?.rxImagePickedTypeRleay.accept(.photoLibrary)
+      self?.rxImagePickedTypeRelay.accept(.photoLibrary)
     }
     
     alert.addAction(cancel)

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
@@ -58,6 +58,8 @@ class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
   
   private let rxCombinedTextDidChangedRelay: PublishRelay<(title: String, content: String)> = PublishRelay()
   
+  private let rxImagePickedTypeRleay: PublishRelay<UIImagePickerController.SourceType> = PublishRelay()
+  
   // MARK: Properties
   lazy var dataSource: Section = Section(configureCell: { [weak self] _, tableView, indexPath, item -> UITableViewCell in
     switch item {
@@ -303,6 +305,12 @@ class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
       .bind(to: reactor.action)
       .disposed(by: self.disposeBag)
     
+    rxImagePickedTypeRleay
+      .map { $0.soureType }
+      .map { Reactor.Action.imagePickerDidTapped($0) }
+      .bind(to: reactor.action)
+      .disposed(by: self.disposeBag)
+    
     rxNoteItemDeleteRelay
       .map { Reactor.Action.noteItemDidDeleted($0) }
       .bind(to: reactor.action)
@@ -397,10 +405,10 @@ extension CreateNoteViewController {
     
     let cancel = UIAlertAction(title: "취소", style: .cancel, handler: nil)
     let camera = UIAlertAction(title: "카메라", style: .default) { [weak self] _ in
-      self?.showPickView(by: .camera)
+      self?.rxImagePickedTypeRleay.accept(.camera)
     }
     let album = UIAlertAction(title: "앨범", style: .default) { [weak self] _ in
-      self?.showPickView(by: .photoLibrary)
+      self?.rxImagePickedTypeRleay.accept(.photoLibrary)
     }
     
     alert.addAction(cancel)

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -50,6 +50,7 @@ final class CreateNoteViewReactor: Reactor {
     case noteItemDidDeleted(IndexPath)
     case showStockItemEditView(IndexPath)
     case stockItemDidUpdated(NoteStock)
+    case imagePickerDidTapped(ImagePickerType)
   }
 
   enum Mutation {
@@ -134,6 +135,8 @@ final class CreateNoteViewReactor: Reactor {
         return self.stockItemDidUpdated(stock)
     case .dismissView:
         return dismissView()
+    case .imagePickerDidTapped(let pickerType):
+        return imagePickerDidTapped(pickerType)
     default:
       return .empty()
     }
@@ -236,6 +239,13 @@ final class CreateNoteViewReactor: Reactor {
         
         return .just(.requestNoteDataDidChanged(requestNote))
     }
+    
+    return .empty()
+  }
+  
+  
+  private func imagePickerDidTapped(_ pickerType: ImagePickerType) -> Observable<Mutation> {
+    
     
     return .empty()
   }

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -17,7 +17,7 @@ final class CreateNoteViewReactor: Reactor {
   enum ViewPresentType {
     case showAlert(String)
     case showPermission(String)
-    case showPhotoPicker
+    case showImageSourceActionSheetView
   }
   
   let scheduler: Scheduler = MainScheduler.asyncInstance
@@ -230,7 +230,7 @@ final class CreateNoteViewReactor: Reactor {
           return .just(.present(.showAlert("이미지는 최대 3개까지 등록 가능합니다.")))
         }
         
-        return .just(.present(.showPhotoPicker))
+        return .just(.present(.showImageSourceActionSheetView))
       case .item:
         imageCellReactor.action.onNext(.removeImage(indexPath))
         

--- a/Tooda/Sources/SupportFiles/Info.plist
+++ b/Tooda/Sources/SupportFiles/Info.plist
@@ -24,6 +24,8 @@
 	<string>$(APP_VERSION)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSCameraUsageDescription</key>
+	<string>&apos;tooda&apos;가 사진을 게시글에 첨부하기 위해 카메라 권한을 사용하도록 허용합니다.</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>
 	<string>&apos;tooda&apos;가 사진을 게시글에 첨부하기 위해 사진 라이브러리에 접근하도록 허용합니다.</string>
 	<key>NSPhotoLibraryUsageDescription</key>


### PR DESCRIPTION
### 수정내역 (필수)
- Info.plist에 카메라 권한 안내 문구 추가하여 크래시가 발생한 문제를 수정했어요.
- RxAuthrization에 camera 관련 옵저버블 프로퍼티 추가
- ImagePickerType을 리액터로 전달하기 위한 열거형 자료형을 추가했어요.
- 노트 입력 화면에서 이미지 액션시트를 눌렀을 때, 카메라/앨범 선택에 따른 Action에 따라 권한을 요청하고, 권한이 거부된 경우 설정화면으로 이동해요. 권한이 허용되어 있으면 각 액션에 맞는 이미지 피커 화면을 호출해요.

### 스크린샷 (선택사항)
![ezgif com-gif-maker](https://user-images.githubusercontent.com/19662529/152359096-251c981e-3fec-4e72-8710-1064914a85ba.gif)
![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/19662529/152359101-4f153e64-3ec9-416f-abf3-12b1ee538f77.gif)

