### PR TITLE
[UI] 노트 리스트에 search 버튼을 연결하고 노트 리스트 셀에 image count를 표시했습니다!

### DIFF
--- a/Tooda/Sources/Scenes/NoteList/Cells/NoteListCell.swift
+++ b/Tooda/Sources/Scenes/NoteList/Cells/NoteListCell.swift
@@ -18,6 +18,7 @@ final class NoteListCell: BaseTableViewCell {
     static let title = TextStyle.subTitleBold(color: .gray1)
     static let recordDate = TextStyle.captionBold(color: .gray3)
     static let description = TextStyle.bodyBold(color: .gray1)
+    static let imageCount = TextStyle.caption(color: .gray2)
   }
   
   // MARK: - UI Components
@@ -62,6 +63,7 @@ final class NoteListCell: BaseTableViewCell {
     edgeInsets: UIEdgeInsets(horizontal: 8, vertical: 2)
   ).then {
     $0.layer.cornerRadius = 8
+    $0.backgroundColor = .white
   }
   
   // MARK: - Overridden: ParentClass
@@ -147,6 +149,13 @@ final class NoteListCell: BaseTableViewCell {
     linkImageView.isHidden = note.noteLinks?.first == nil ? true : false
     descriptionLabel.attributedText = note.content.styled(with: Font.description)
     updateImages(images: note.noteImages)
+    
+    if note.noteImages.count > 1 {
+      imageCountLabel.isHidden = false
+      imageCountLabel.attributedText = "+ \(note.noteImages.count)".styled(with: Font.imageCount)
+    } else {
+      imageCountLabel.isHidden = true
+    }
     
     DispatchQueue.main.async {
       self.descriptionLabel.setExpandActionIfPossible("더보기")

--- a/Tooda/Sources/Scenes/NoteList/NoteListViewController.swift
+++ b/Tooda/Sources/Scenes/NoteList/NoteListViewController.swift
@@ -100,6 +100,11 @@ final class NoteListViewController: BaseViewController<NoteListReactor> {
       .bind(to: reactor.action)
       .disposed(by: disposeBag)
     
+    searchBarButton.rx.tap
+      .map { _ in NoteListReactor.Action.searchButtonTap }
+      .bind(to: reactor.action)
+      .disposed(by: disposeBag)
+    
     dismissBarButton.rx.tap
       .map { _ in NoteListReactor.Action.dismiss }
       .bind(to: reactor.action)


### PR DESCRIPTION
### 수정내역 (필수)
- search 버튼 연결
- 노트 리스트 셀에 image count를 표시
- 기존 indicator 로딩 시작 시점 및 종료 시점 네트워크 스트림에 따라 수정

### 영상 (선택사항)

https://user-images.githubusercontent.com/31857308/152367964-6f0765d1-a7c2-48fd-9d73-21362fb47e7d.MP4

