### PR TITLE
[Domain] 노트 입력/수정 화면과 종목 변동률 입력화면의 이슈를 수정했어요.

### DIFF
--- a/Tooda/Sources/Scenes/AddStock/StockRateInputViewController.swift
+++ b/Tooda/Sources/Scenes/AddStock/StockRateInputViewController.swift
@@ -225,6 +225,7 @@ class StockRateInputViewController: BaseViewController<StockRateInputReactor> {
       .disposed(by: self.disposeBag)
     
     self.textField.rx.text.orEmpty
+      .skip(1)
       .map { Float($0) }
       .distinctUntilChanged()
       .map { Reactor.Action.textFieldDidChanged($0) }

--- a/Tooda/Sources/Scenes/CreateNote/Cells/NoteImageItemCell.swift
+++ b/Tooda/Sources/Scenes/CreateNote/Cells/NoteImageItemCell.swift
@@ -89,6 +89,7 @@ extension NoteImageItemCell {
 }
 
 extension String {
+  @available(iOS, deprecated, message: "성능 이슈가 심해서 비동기 처리하는 로직을 사용할 예정이에요.")
   var urlImage: UIImage? {
     guard let url = URL(string: self),
           let data = try? Data(contentsOf: url),

--- a/Tooda/Sources/Scenes/CreateNote/Cells/NoteLinkCell.swift
+++ b/Tooda/Sources/Scenes/CreateNote/Cells/NoteLinkCell.swift
@@ -46,7 +46,10 @@ class NoteLinkCell: BaseTableViewCell, View {
     $0.translatesAutoresizingMaskIntoConstraints = false
   }
   
-  private let placeHolderView = ImagePlaceHolderView(image: UIImage(type: .iconImagePlaceHolder))
+  private let placeHolderView = ImagePlaceHolderView(image: UIImage(type: .iconImagePlaceHolder)).then {
+    $0.layer.borderColor = nil
+    $0.layer.masksToBounds = true
+  }
   
   private let thumnailView = UIImageView().then {
     $0.contentMode = .scaleAspectFill

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
@@ -468,18 +468,19 @@ extension CreateNoteViewController {
   private func generateEditableSwipeConfigure(at indexPath: IndexPath) -> UISwipeActionsConfiguration? {
     switch dataSource[indexPath] {
       case .stock:
-        return self.generateSwipeAction(indexPath: indexPath, name: "종목")
+        let delete = self.deleteCellAction(at: indexPath, name: "종목")
+        let edit = self.editCellAction(at: indexPath)
+        return self.generateSwipeAction(actions: [delete, edit])
       case .link:
-        return self.generateSwipeAction(indexPath: indexPath, name: "링크")
+        let delete = self.deleteCellAction(at: indexPath, name: "링크")
+        return self.generateSwipeAction(actions: [delete])
       default:
         return nil
     }
   }
   
-  private func generateSwipeAction(indexPath: IndexPath, name: String) -> UISwipeActionsConfiguration? {
-    let delete = self.deleteCellAction(at: indexPath, name: name)
-    let edit = self.editCellAction(at: indexPath)
-    let swipeActionConfig = UISwipeActionsConfiguration(actions: [delete, edit])
+  private func generateSwipeAction(actions: [UIContextualAction]) -> UISwipeActionsConfiguration? {
+    let swipeActionConfig = UISwipeActionsConfiguration(actions: actions)
     swipeActionConfig.performsFirstActionWithFullSwipe = false
     return swipeActionConfig
   }

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -420,13 +420,12 @@ self.dependency.coordinator.transition(
     
     return Observable.concat([
       .just(.requestNoteDataDidChanged(requestNote)),
-      self.registNoteAndDismissView()
+      self.registNoteAndDismissView(requestNote)
     ])
   }
   
-  // FIXME: 진수님 작업 완료되면 .map에 커스텀 JsonDecoder를 변경할게요!
-  private func registNoteAndDismissView() -> Observable<Mutation> {
-    return self.dependency.service.request(NoteAPI.create(dto: self.currentState.requestNote))
+  private func registNoteAndDismissView(_ requestNote: NoteRequestDTO) -> Observable<Mutation> {
+    return self.dependency.service.request(NoteAPI.create(dto: requestNote))
       .toodaMap(Note.self)
       .asObservable()
       .flatMap { [weak self] note -> Observable<Mutation> in

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -341,16 +341,20 @@ extension CreateNoteViewReactor {
     ])
   }
   
-  private func makeLinkSectionItem(_ url: String) -> Observable<Mutation> {
+  private func makeLinkSectionItem(_ urlString: String) -> Observable<Mutation> {
+    
+    //FIXME: URL 관련 안내 Alert을 보여줘야 할것 같은데 present 관련 이슈가 좀 있어서 추후에 처리할게요.
+    guard URL(string: urlString) != nil else { return .empty() }
+    
     let linkReactor = NoteLinkCellReactor(dependency: .init(
       service: self.dependency.linkPreviewService),
-                                          payload: url
+                                          payload: urlString
     )
     
     let linkSectionItem: NoteSectionItem = NoteSectionItem.link(linkReactor)
     
     var requestNote = self.currentState.requestNote
-    requestNote.links.append(url)
+    requestNote.links.append(urlString)
     
     return .concat([
       .just(.requestNoteDataDidChanged(requestNote)),

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -473,12 +473,12 @@ extension CreateNoteViewReactor {
     
     return Observable.concat([
       .just(.requestNoteDataDidChanged(requestNote)),
-      self.updateNoteAndDismissView()
+      self.updateNoteAndDismissView(requestNote)
     ])
   }
   
-  private func updateNoteAndDismissView() -> Observable<Mutation> {
-    return self.dependency.service.request(NoteAPI.update(dto: self.currentState.requestNote))
+  private func updateNoteAndDismissView(_ requestNote: NoteRequestDTO) -> Observable<Mutation> {
+    return self.dependency.service.request(NoteAPI.update(dto: requestNote))
       .toodaMap(Note.self)
       .asObservable()
       .flatMap { [weak self] note -> Observable<Mutation> in

--- a/Tooda/Sources/Scenes/NoteDetail/Cells/NoteDetailImageCell.swift
+++ b/Tooda/Sources/Scenes/NoteDetail/Cells/NoteDetailImageCell.swift
@@ -38,14 +38,10 @@ final class NoteDetailImageCell: BaseTableViewCell {
     
     self.indicatorView.startAnimating()
     
-    DispatchQueue.global(qos: .background).async {
-      guard let image = UIImage(data: data) else { return }
-      
-      DispatchQueue.main.async { [weak self] in
-        self?.imageContainerView.image = image
-        self?.indicatorView.stopAnimating()
-      }
-    }
+    guard let image = UIImage(data: data) else { return }
+    self.imageContainerView.image = image
+    
+    self.indicatorView.stopAnimating()
   }
   
   override func setupConstraints() {


### PR DESCRIPTION
### 수정내역 (필수)
- 링크 Cell에서 placeHolderView에 설정되어있는 borderLine을 제거했어요.
- 노트 등록/수정 화면에서 링크셀에 대한 수정 스와이프 Action을 수정했어요. Action을 수정함에 따라 기존의 swipe configuration 메소드도 변경했어요.
- 노트 등록/수정 화면에서 URL 변환에 성공했을 때만 link아이템을 만들어 주도록 로직을 수정했어요.
- 노트 등록/수정 시 currentState가 아닌 Mutation 메소드에서 파라미터 값을 통해 API를 수행하도록 수정했어요. **(한줄평이 선택한대로 들어가지 않는 이슈 수정)**
- 변동률 입력하기 화면에 진입했을 때 textField 스트림이 발생해 등록 버튼이 비활성화 되던 문제를 수정했어요.
- String Extension에서 urlImage를 만드는 로직이 성능 이슈가 있어 deprecated 어노테이션을 추가했어요.
- 노트 상세 화면에서 이미지 셀 configure 로직에서 불필요한 동시성제어 로직을 제거했어요.