### PR TITLE
[Domain] 노트 상세 화면에서 노트 삭제 기능을 구현했어요.

### DIFF
--- a/Tooda/Sources/Core/AppFactory.swift
+++ b/Tooda/Sources/Core/AppFactory.swift
@@ -193,6 +193,7 @@ final class AppFactory: AppFactoryType {
           service: self.dependency.appInject.resolve(NetworkingProtocol.self),
           coordinator: self.dependency.appInject.resolve(AppCoordinatorType.self),
           linkPreviewService: self.dependency.appInject.resolve(LinkPreViewServiceType.self),
+          noteEventBus: NoteEventBus.event,
           payload: payload
         )
       )

--- a/Tooda/Sources/Core/AppFactory.swift
+++ b/Tooda/Sources/Core/AppFactory.swift
@@ -193,9 +193,9 @@ final class AppFactory: AppFactoryType {
           service: self.dependency.appInject.resolve(NetworkingProtocol.self),
           coordinator: self.dependency.appInject.resolve(AppCoordinatorType.self),
           linkPreviewService: self.dependency.appInject.resolve(LinkPreViewServiceType.self),
-          noteEventBus: NoteEventBus.event,
-          payload: payload
-        )
+          noteEventBus: NoteEventBus.event
+        ),
+        payload: payload
       )
 
       return NoteDetailViewController(reactor: reactor)

--- a/Tooda/Sources/Networking/API/NoteAPI.swift
+++ b/Tooda/Sources/Networking/API/NoteAPI.swift
@@ -32,7 +32,7 @@ extension NoteAPI: BaseAPI {
       case .addImage:
         return "diary/image"
       case .delete(let id):
-        return "/diary/\(id)"
+        return "diary/\(id)"
       case .update(let dto):
         return "diary/\(dto.id ?? "")"
       case .detail(let id):

--- a/Tooda/Sources/Scenes/NoteDetail/NoteDetailReactor.swift
+++ b/Tooda/Sources/Scenes/NoteDetail/NoteDetailReactor.swift
@@ -24,8 +24,6 @@ final class NoteDetailReactor: Reactor {
     let coordinator: AppCoordinatorType
     let linkPreviewService: LinkPreViewServiceType
     let noteEventBus: PublishSubject<NoteEventBus.Event>
-    // TODO: Payload는 별도로 분리해요.
-    let payload: Payload
   }
 
   // MARK: Reactor
@@ -60,11 +58,14 @@ final class NoteDetailReactor: Reactor {
   private let dependency: Dependency
 
   let initialState: State
+  
+  let payload: Payload
 
-  init(dependency: Dependency) {
+  init(dependency: Dependency, payload: Payload) {
     self.dependency = dependency
+    self.payload = payload
     self.initialState =
-      State.generateInitialState(noteID: dependency.payload.id)
+      State.generateInitialState(noteID: payload.id)
   }
 }
 

--- a/Tooda/Sources/Scenes/NoteDetail/NoteDetailReactor.swift
+++ b/Tooda/Sources/Scenes/NoteDetail/NoteDetailReactor.swift
@@ -32,6 +32,7 @@ final class NoteDetailReactor: Reactor {
     case loadData
     case back
     case editNote
+    case deleteNote
     case linkItemDidTapped(String)
   }
 
@@ -84,6 +85,8 @@ extension NoteDetailReactor {
       case .editNote:
         self.editNote()
         return .empty()
+    case .deleteNote:
+      return deleteNoteMutation()
     case .linkItemDidTapped(let urlString):
       return linkItemDidTapped(urlString)
     }
@@ -170,6 +173,22 @@ extension NoteDetailReactor {
     self.dependency.coordinator.transition(to: .modifyNote(dateString: dateString,
                                                            note: noteRequestDTO),
                                            using: .modal, animated: true, completion: nil)
+  }
+  
+  private func deleteNoteMutation() -> Observable<Mutation> {
+    let noteID = "\(self.currentState.noteID)"
+    return self.dependency.service.request(NoteAPI.delete(id: noteID))
+      .asObservable()
+      .flatMap { [weak self] _ -> Observable<Mutation> in
+        
+        self?.dependency.coordinator.close(
+          style: .pop,
+          animated: true,
+          completion: nil
+        )
+        
+        return .empty()
+      }
   }
   
   private func linkItemDidTapped(_ urlString: String) -> Observable<Mutation> {

--- a/Tooda/Sources/Scenes/NoteDetail/NoteDetailReactor.swift
+++ b/Tooda/Sources/Scenes/NoteDetail/NoteDetailReactor.swift
@@ -23,6 +23,8 @@ final class NoteDetailReactor: Reactor {
     let service: NetworkingProtocol
     let coordinator: AppCoordinatorType
     let linkPreviewService: LinkPreViewServiceType
+    let noteEventBus: PublishSubject<NoteEventBus.Event>
+    // TODO: Payload는 별도로 분리해요.
     let payload: Payload
   }
 
@@ -181,7 +183,12 @@ extension NoteDetailReactor {
       .asObservable()
       .flatMap { [weak self] _ -> Observable<Mutation> in
         
-        self?.dependency.coordinator.close(
+        guard let self = self,
+                let note = self.currentState.note else { return .empty() }
+        
+        self.dependency.noteEventBus.onNext(.deleteNote(note))
+        
+        self.dependency.coordinator.close(
           style: .pop,
           animated: true,
           completion: nil

--- a/Tooda/Sources/Scenes/NoteDetail/NoteDetailViewController.swift
+++ b/Tooda/Sources/Scenes/NoteDetail/NoteDetailViewController.swift
@@ -79,7 +79,7 @@ final class NoteDetailViewController: BaseViewController<NoteDetailReactor> {
     }
   })
   
-  
+  private let deleteNoteButtonRelay: PublishRelay<Void> = PublishRelay()
   private let editNoteButtonRelay: PublishRelay<Void> = PublishRelay()
   
   private let linkItemCellDidTappedRelay: PublishRelay<String> = PublishRelay()
@@ -190,7 +190,9 @@ final class NoteDetailViewController: BaseViewController<NoteDetailReactor> {
           UIAlertAction(
             title: "노트 삭제",
             style: .destructive,
-            handler: nil
+            handler: { [weak self] _ in
+              self?.deleteActionSheetDidTapped()
+            }
           )
         )
         
@@ -215,6 +217,23 @@ final class NoteDetailViewController: BaseViewController<NoteDetailReactor> {
     }
     .disposed(by: disposeBag)
 
+  }
+  
+  private func deleteActionSheetDidTapped() {
+    let alertController = UIAlertController(title: "정말 삭제할까요?",
+                                            message: "한 번 삭제하면 되돌릴 수 없어요.",
+                                            preferredStyle: .alert)
+    
+    let ok = UIAlertAction(title: "확인", style: .destructive, handler: { [weak self] _ in
+      self?.deleteNoteButtonRelay.accept(())
+    })
+    
+    let cancel = UIAlertAction(title: "취소", style: .default, handler: nil)
+    
+    alertController.addAction(cancel)
+    alertController.addAction(ok)
+    
+    self.present(alertController, animated: true, completion: nil)
   }
   
 }

--- a/Tooda/Sources/Scenes/NoteDetail/NoteDetailViewController.swift
+++ b/Tooda/Sources/Scenes/NoteDetail/NoteDetailViewController.swift
@@ -164,6 +164,11 @@ final class NoteDetailViewController: BaseViewController<NoteDetailReactor> {
       .bind(to: reactor.action)
       .disposed(by: self.disposeBag)
     
+    self.deleteNoteButtonRelay
+      .map { NoteDetailReactor.Action.deleteNote }
+      .bind(to: reactor.action)
+      .disposed(by: self.disposeBag)
+    
     self.linkItemCellDidTappedRelay
       .map { NoteDetailReactor.Action.linkItemDidTapped($0) }
       .bind(to: reactor.action)


### PR DESCRIPTION
### 수정내역 (필수)
- 노트 삭제 Alert용 메소드를 추가했어요.
- 노트 삭제 AlertController에서 삭제 handler 이벤트를 전달하기 위한 relay 프로퍼티를 추가했어요.
- 노트 상세 Reactor에서 노트 삭제를 위한 Action과 Mutation을 구현했어요.
- 노트 상세 Reactor에 Gloabl 이벤트와 관련된 Depdency를 추가했어요.
- 노트 상세 Reactor Dependency의 payload 프로퍼티를 제거하고 Reactor의 멤버변수로 선언했어요.
- 노트 API에서 삭제 case에 대한 path를 수정했어요.

### 스크린샷 (선택사항)
![ezgif com-gif-maker (2)](https://user-images.githubusercontent.com/19662529/152558078-f6f531a6-8ed7-440d-ad4c-075fb5f8b77a.gif)

