### PR TITLE
[Utils] 노트 등록/수정 화면에서 사진이나 앨범을 선택하면 CropView를 사용할 수 있어요.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -23,6 +23,7 @@ target 'Tooda' do
   # Comment the next line if you don't want to use dynamic frameworks
   shared_pods
   pod 'SwiftLint'
+  pod 'Mantis', '~> 1.9.0'
   pod 'netfox', configuration: %w(Debug)
 end
 


### PR DESCRIPTION
### 수정내역 (필수)
- 이미지 크롭을 위한 써드파티 Dependency를 추가했어요. [참고](https://github.com/guoyingtao/Mantis)
- 노트 등록/수정 화면에서 사진을 찍거나 앨범에서 사진을 선택하면 이미지를 커스텀할 수 있는 CropViewController를 호출하게 변경했어요.

### 스크린샷 (선택사항)
![ezgif com-gif-maker (4)](https://user-images.githubusercontent.com/19662529/152668699-af80e085-63e4-4c94-8d6d-592c5c0f6f44.gif)

