### PR TITLE
[Domain] 노트 등록/수정 화면에서 네트워킹 에러 처리를 위한 스낵바를 추가했어요. 그외 기타 기능 추가

### DIFF
--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
@@ -339,6 +339,14 @@ class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
       .drive(onNext: { [weak self] in
         self?.registerButton.setOnOff(isOn: $0)
       }).disposed(by: self.disposeBag)
+    
+    reactor.state.map { $0.snackBarInfo }
+      .asDriver(onErrorJustReturn: nil)
+      .compactMap { $0 }
+      .drive { info in
+        SnackBarManager.shared.display(type: info.type, title: info.title)
+      }
+      .disposed(by: disposeBag)
   }
 }
 

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
@@ -347,6 +347,13 @@ class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
         SnackBarManager.shared.display(type: info.type, title: info.title)
       }
       .disposed(by: disposeBag)
+    
+    reactor.state
+      .compactMap { $0.shouldKeyboardDismissed }
+      .asDriver(onErrorJustReturn: false)
+      .drive(onNext: { [weak self] in
+        self?.view.endEditing($0)
+      }).disposed(by: self.disposeBag)
   }
 }
 

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -78,6 +78,7 @@ final class CreateNoteViewReactor: Reactor {
     var presentType: ViewPresentType?
     var shouldReigsterButtonEnabled: Bool = false
     var requestNote: NoteRequestDTO = NoteRequestDTO()
+    var snackBarInfo: SnackBarEventBus.SnackBarInfo?
   }
   
   struct Payload {
@@ -163,6 +164,7 @@ final class CreateNoteViewReactor: Reactor {
       $0.shouldReigsterButtonEnabled = state.shouldReigsterButtonEnabled
       $0.presentType = nil
       $0.requestNote = state.requestNote
+      $0.snackBarInfo = nil
     }
     
     switch mutation {

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -448,8 +448,16 @@ self.dependency.coordinator.transition(
   
   private func registNoteAndDismissView(_ requestNote: NoteRequestDTO) -> Observable<Mutation> {
     return self.dependency.service.request(NoteAPI.create(dto: requestNote))
-      .toodaMap(Note.self)
+      .toodaMap(Note?.self)
+      .catch({ [weak self] _ in
+        self?.snackBarMutationStream.accept(
+          (type: .negative,
+           title: "네트워크 연결에 실패했습니다 :(")
+        )
+        return Single.just(nil)
+      })
       .asObservable()
+      .compactMap { $0 }
       .flatMap { [weak self] note -> Observable<Mutation> in
         if "\(note.id)".isNotEmpty {
           return self?.dimissViewWithAddCompletion(note) ?? .empty()
@@ -503,8 +511,16 @@ extension CreateNoteViewReactor {
   
   private func updateNoteAndDismissView(_ requestNote: NoteRequestDTO) -> Observable<Mutation> {
     return self.dependency.service.request(NoteAPI.update(dto: requestNote))
-      .toodaMap(Note.self)
+      .toodaMap(Note?.self)
+      .catch({ [weak self] _ in
+        self?.snackBarMutationStream.accept(
+          (type: .negative,
+           title: "네트워크 연결에 실패했습니다 :(")
+        )
+        return Single.just(nil)
+      })
       .asObservable()
+      .compactMap { $0 }
       .flatMap { [weak self] note -> Observable<Mutation> in
         return self?.dimissViewWithUpdateCompletion(note) ?? .empty()
       }

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -74,6 +74,7 @@ final class CreateNoteViewReactor: Reactor {
     case requestNoteDataDidChanged(NoteRequestDTO)
     case fetchEmptyStockItem([NoteSectionItem])
     case setSnackBarInfo(SnackBarEventBus.SnackBarInfo)
+    case shouldKeyboardDismissed(Bool)
   }
 
   struct State: Then {
@@ -82,6 +83,7 @@ final class CreateNoteViewReactor: Reactor {
     var shouldReigsterButtonEnabled: Bool = false
     var requestNote: NoteRequestDTO = NoteRequestDTO()
     var snackBarInfo: SnackBarEventBus.SnackBarInfo?
+    var shouldKeyboardDismissed: Bool?
   }
   
   struct Payload {
@@ -170,6 +172,7 @@ final class CreateNoteViewReactor: Reactor {
       $0.presentType = nil
       $0.requestNote = state.requestNote
       $0.snackBarInfo = nil
+      $0.shouldKeyboardDismissed = nil
     }
     
     switch mutation {
@@ -195,6 +198,8 @@ final class CreateNoteViewReactor: Reactor {
       newState.sections[NoteSection.Identity.addStock.rawValue].items = sectionItems
     case .setSnackBarInfo(let info):
       newState.snackBarInfo = info
+    case .shouldKeyboardDismissed(let dismissed):
+      newState.shouldKeyboardDismissed = dismissed
     }
 
     return newState
@@ -443,6 +448,7 @@ self.dependency.coordinator.transition(
     requestNote.sticker = sticker
     
     return Observable.concat([
+      .just(.shouldKeyboardDismissed(true)),
       .just(.requestNoteDataDidChanged(requestNote)),
       self.registNoteAndDismissView(requestNote)
     ])
@@ -506,6 +512,7 @@ extension CreateNoteViewReactor {
     requestNote.sticker = sticker
     
     return Observable.concat([
+      .just(.shouldKeyboardDismissed(true)),
       .just(.requestNoteDataDidChanged(requestNote)),
       self.updateNoteAndDismissView(requestNote)
     ])

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -18,6 +18,8 @@ final class CreateNoteViewReactor: Reactor {
     static let stockMaxCount: Int = 5
     static let linkMaxCount: Int = 2
     static let imageMaxCount: Int = 3
+    
+    static let networkingErrorMessage: String = "네트워크 연결에 실패했습니다 :("
   }
   
   enum ViewPresentType {
@@ -452,7 +454,7 @@ self.dependency.coordinator.transition(
       .catch({ [weak self] _ in
         self?.snackBarMutationStream.accept(
           (type: .negative,
-           title: "네트워크 연결에 실패했습니다 :(")
+           title: Const.networkingErrorMessage)
         )
         return Single.just(nil)
       })
@@ -515,7 +517,7 @@ extension CreateNoteViewReactor {
       .catch({ [weak self] _ in
         self?.snackBarMutationStream.accept(
           (type: .negative,
-           title: "네트워크 연결에 실패했습니다 :(")
+           title: Const.networkingErrorMessage)
         )
         return Single.just(nil)
       })


### PR DESCRIPTION
### 수정내역 (필수)
- 노트 등록/수정 화면에서 등록/수정 API에 에러가 발생하면 스낵바를 보여줘요.
- 노트 등록/수정 화면에서 등록/수정 > 한줄평 팝업 입력을 할때, 키보드를 내려줘요.

### 스크린샷 (선택사항)
![ezgif com-gif-maker (5)](https://user-images.githubusercontent.com/19662529/152670722-62cec341-eee3-48db-a314-b639cf480f57.gif)

