### PR TITLE
[Domain] 노트 등록/수정 화면에서 기본 Alert에 title과 message를 볼 수 있어요.

### DIFF
--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
@@ -383,8 +383,8 @@ extension CreateNoteViewController {
 extension CreateNoteViewController {
   func present(by: Reactor.ViewPresentType) {
     switch by {
-      case .showAlert(let message):
-        self.showAlert(message: message)
+      case .showAlert(let title, let message):
+        self.showAlert(title: title, message: message)
       case .showPermission(let message):
         self.showAlertAndOpenAppSetting(message: message)
       case .showImageSourceActionSheetView:
@@ -403,8 +403,8 @@ extension CreateNoteViewController {
     }
   }
   
-  func showAlert(message: String?) {
-    let alertController = UIAlertController(title: nil, message: message, preferredStyle: .alert)
+  func showAlert(title: String?, message: String?) {
+    let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
     
     let ok = UIAlertAction.init(title: "확인", style: .default, handler: nil)
     

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -372,8 +372,11 @@ extension CreateNoteViewReactor {
   
   private func makeLinkSectionItem(_ urlString: String) -> Observable<Mutation> {
     
-    //FIXME: URL 관련 안내 Alert을 보여줘야 할것 같은데 present 관련 이슈가 좀 있어서 추후에 처리할게요.
-    guard URL(string: urlString) != nil else { return .empty() }
+    // FIXME: 키보드를 내린후에 Alert을 호출하도록 해요.
+    guard URL(string: urlString) != nil else {
+      return .just(.present(.showAlert(title: "추가할 수 없는 URL이에요.",
+                                       message: "정확한 URL을 다시 입력해주세요.")))
+    }
     
     let linkReactor = NoteLinkCellReactor(dependency: .init(
       service: self.dependency.linkPreviewService),

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -23,7 +23,7 @@ final class CreateNoteViewReactor: Reactor {
   }
   
   enum ViewPresentType {
-    case showAlert(String)
+    case showAlert(title: String?, message: String)
     case showPermission(String)
     case showImageSourceActionSheetView
     case showImagePickerView(ImagePickerType)
@@ -263,7 +263,7 @@ final class CreateNoteViewReactor: Reactor {
     switch imageSectionItem {
       case .empty:
         guard imageCellReactor.currentState.sections[NoteImageSection.Identity.item.rawValue].items.count < Const.imageMaxCount else {
-          return .just(.present(.showAlert("이미지는 최대 \(Const.imageMaxCount)개까지 등록 가능합니다.")))
+          return .just(.present(.showAlert(title: "사진은 최대 \(Const.imageMaxCount)개까지\n추가할 수 있어요.", message: "사진을 추가하시려면 기존 사진을\n삭제 후 추가해주세요.")))
         }
         
         return .just(.present(.showImageSourceActionSheetView))
@@ -421,7 +421,8 @@ extension CreateNoteViewReactor {
                                              using: .modal,
                                              animated: false)
     } else {
-      return .just(.present(.showAlert("링크는 최대 \(maxItemCount)개까지 등록 가능합니다.")))
+      return .just(.present(.showAlert(title: "링크는 최대 \(maxItemCount)개까지\n추가할 수 있어요.",
+                                      message: "링크를 추가하시려면 기존 링크를\n삭제 후 추가해주세요.")))
     }
     
     return .empty()

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -371,11 +371,12 @@ extension CreateNoteViewReactor {
   }
   
   private func makeLinkSectionItem(_ urlString: String) -> Observable<Mutation> {
-    
-    // FIXME: 키보드를 내린후에 Alert을 호출하도록 해요.
     guard URL(string: urlString) != nil else {
-      return .just(.present(.showAlert(title: "추가할 수 없는 URL이에요.",
+      return .concat([
+        .just(.shouldKeyboardDismissed(true)),
+        .just(.present(.showAlert(title: "추가할 수 없는 URL이에요.",
                                        message: "정확한 URL을 다시 입력해주세요.")))
+      ])
     }
     
     let linkReactor = NoteLinkCellReactor(dependency: .init(

--- a/Tooda/Sources/Scenes/OneLineReviewPopUp/PopUpReactor.swift
+++ b/Tooda/Sources/Scenes/OneLineReviewPopUp/PopUpReactor.swift
@@ -130,14 +130,14 @@ extension PopUpReactor {
   }
   
   private func didAddTextInputMutation(textInput: String) -> Observable<Mutation> {
-    if case let .textInput(relay) = dependency.type {
-        relay.accept(textInput)
-    }
-    
     dependency.coordinator.close(
       style: .dismiss,
       animated: false,
-      completion: nil
+      completion: { [weak self] in
+        if case let .textInput(relay) = self?.dependency.type {
+          relay.accept(textInput)
+        }
+      }
     )
     
     return Observable<Mutation>.empty()


### PR DESCRIPTION
### 수정내역 (필수)
- PopUpReactor에서 링크 urlString을 dismiss completion에서 전달하게 수정했어요.
- 노트 등록/수정 Reactor에서 AlertType case에 title 파라미터를 추가했어요.
- 사진, 링크 추가시 전달할 Alert 형식과 문구를 변경했어요.
