### PR TITLE
[Domain] 투다의 로그인 관련 이슈를 수정하고 등록/수정 화면을 개선했어요.

### DIFF
--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
@@ -45,6 +45,11 @@ class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
   private enum Metric {
     static let linkButtonSize: CGFloat = 20.0
   }
+  
+  private let indicatorView = UIActivityIndicatorView(style: .large).then {
+    $0.hidesWhenStopped = true
+    $0.color = .mainGreen
+  }
 
   // MARK: Custom Action
   
@@ -219,7 +224,7 @@ class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
 
     self.view.backgroundColor = .white
 
-    [tableView, linkStackView].forEach {
+    [tableView, linkStackView, indicatorView].forEach {
       self.view.addSubview($0)
     }
     
@@ -253,6 +258,10 @@ class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
       $0.centerY.equalToSuperview()
       $0.leading.equalToSuperview().offset(20)
       $0.size.equalTo(Metric.linkButtonSize)
+    }
+    
+    self.indicatorView.snp.makeConstraints {
+      $0.center.equalToSuperview()
     }
   }
 
@@ -375,6 +384,16 @@ extension CreateNoteViewController {
   @objc
   private func contentViewDidTap(_ sender: Any?) {
     self.view.endEditing(true)
+  }
+  
+  private func startIndicator() {
+    self.indicatorView.startAnimating()
+    self.view.isUserInteractionEnabled = false
+  }
+  
+  private func stopIndicator() {
+    self.indicatorView.stopAnimating()
+    self.view.isUserInteractionEnabled = true
   }
 }
 

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
@@ -364,6 +364,17 @@ class CreateNoteViewController: BaseViewController<CreateNoteViewReactor> {
       .drive(onNext: { [weak self] in
         self?.view.endEditing($0)
       }).disposed(by: self.disposeBag)
+    
+    reactor.state
+      .map { $0.isLoading }
+      .distinctUntilChanged()
+      .subscribe(onNext: { [weak self] isLoading in
+        if isLoading {
+          self?.startIndicator()
+        } else {
+          self?.stopIndicator()
+        }
+      }).disposed(by: self.disposeBag)
   }
 }
 

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewController.swift
@@ -507,7 +507,7 @@ extension CreateNoteViewController: UIImagePickerControllerDelegate, UINavigatio
 extension CreateNoteViewController: CropViewControllerDelegate {
   func cropViewControllerDidCrop(_ cropViewController: CropViewController, cropped: UIImage, transformation: Transformation, cropInfo: CropInfo) {
     
-    if let croppedData = cropped.jpegData(compressionQuality: 1.0) {
+    if let croppedData = cropped.jpegData(compressionQuality: 0.3) {
       cropViewController.dismiss(animated: true, completion: { [weak self] in
         self?.imagePickerDataSelectedRelay.accept(croppedData)
       })

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -75,6 +75,7 @@ final class CreateNoteViewReactor: Reactor {
     case fetchEmptyStockItem([NoteSectionItem])
     case setSnackBarInfo(SnackBarManager.SnackBarInfo)
     case shouldKeyboardDismissed(Bool)
+    case setLoading(Bool)
   }
 
   struct State: Then {
@@ -84,6 +85,7 @@ final class CreateNoteViewReactor: Reactor {
     var requestNote: NoteRequestDTO = NoteRequestDTO()
     var snackBarInfo: SnackBarManager.SnackBarInfo?
     var shouldKeyboardDismissed: Bool?
+    var isLoading: Bool = false
   }
   
   struct Payload {
@@ -173,6 +175,7 @@ final class CreateNoteViewReactor: Reactor {
       $0.requestNote = state.requestNote
       $0.snackBarInfo = nil
       $0.shouldKeyboardDismissed = nil
+      $0.isLoading = false
     }
     
     switch mutation {
@@ -200,6 +203,8 @@ final class CreateNoteViewReactor: Reactor {
       newState.snackBarInfo = info
     case .shouldKeyboardDismissed(let dismissed):
       newState.shouldKeyboardDismissed = dismissed
+    case .setLoading(let isLoading):
+      newState.isLoading = isLoading
     }
 
     return newState

--- a/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
+++ b/Tooda/Sources/Scenes/CreateNote/CreateNoteViewReactor.swift
@@ -129,10 +129,14 @@ final class CreateNoteViewReactor: Reactor {
     case .didSelectedImageItem(let index):
         return didSelectedImageItem(index)
     case .uploadImage(let data):
-      return self.uploadImage(data)
-        .flatMap { [weak self] imageURL -> Observable<Mutation> in
-          return self?.fetchImageSection(with: imageURL) ?? .empty()
-      }
+      return Observable.concat([
+        .just(Mutation.setLoading(true)),
+        self.uploadImage(data)
+          .flatMap { [weak self] imageURL -> Observable<Mutation> in
+            return self?.fetchImageSection(with: imageURL) ?? .empty()
+          },
+        .just(Mutation.setLoading(false))
+      ])
     case .showAddStockView:
       return presentAddStockView()
     case .stockItemDidAdded(let stock):

--- a/Tooda/Sources/Scenes/Login/LoginReactor.swift
+++ b/Tooda/Sources/Scenes/Login/LoginReactor.swift
@@ -31,7 +31,6 @@ final class LoginReactor: Reactor {
   }
   
   enum Mutation {
-    case setAppToken(token: AppToken)
     case setIsAuthorized(isAuthorized: Bool)
     case setSnackBarInfo(SnackBarManager.SnackBarInfo)
   }
@@ -92,13 +91,22 @@ extension LoginReactor {
               )
             } else {
               return Observable<Mutation>.concat([
-                Observable<Mutation>.just(Mutation.setAppToken(token: token)),
+                self.setAppToken(token: token),
                 Observable<Mutation>.just(Mutation.setIsAuthorized(isAuthorized: true)),
                 self.routeToHomeMutation()
               ])
             }
           }
       }
+  }
+  
+  private func setAppToken(token: AppToken) -> Observable<Mutation> {
+    dependency.localPersistanceManager.setObject(
+      value: token,
+      forKey: .appToken
+    )
+    
+    return .empty()
   }
   
   private func routeToHomeMutation() -> Observable<Mutation> {
@@ -146,11 +154,6 @@ extension LoginReactor {
     }
     
     switch mutation {
-    case let .setAppToken(token):
-      dependency.localPersistanceManager.setObject(
-        value: token,
-        forKey: .appToken
-      )
     case let .setIsAuthorized(isAuthorized):
       newState.isAuthorized = isAuthorized
     case let .setSnackBarInfo(info):


### PR DESCRIPTION
### 수정내역 (필수)
- 앱 설치 후 최초로, 로그인을 시도했을 때 Reactor에서 로컬 저장소에 앱 토큰을 저장하기 전 홈 화면으로 이동하여 Meta API에 토큰이 전달되지 않는 문제를 수정했어요.
- 노트 등록/수정 화면에 인디케이터를 추가했어요. - 이미지 등록중, 노트 등록/수정 시에 인디케이터를 돌려요.
- 노트 등록/수정 화면에서 피커에서 선택한 이미지의 해상도를 조절했어요. 모바일 환경에서는 0.3이여도 충분히 잘 나오네요.
