### PR TITLE
[Bug] NSAttributedString range 이슈로 crash 나는 부분 수정

### DIFF
--- a/Tooda/Sources/Common/Extensions/NSAttributedString+Extension.swift
+++ b/Tooda/Sources/Common/Extensions/NSAttributedString+Extension.swift
@@ -70,6 +70,7 @@ extension NSAttributedString {
 
   func alignment(with alignment: NSTextAlignment) -> NSAttributedString {
     guard let mutableAttr = self.mutableCopy() as? NSMutableAttributedString,
+          string.count > 0,
           let styleAttribute = mutableAttr.attributes(
             at: 0,
             effectiveRange: nil


### PR DESCRIPTION
### 수정내역 (필수)

- 노트에 텍스트가 없는 경우 Range 이슈가 발생하여 수정

### 스크린샷 (선택사항)

- 내용이 없는 노트 만들어서 재현

<img width="500" alt="Screen Shot 2022-12-12 at 12 29 13 AM" src="https://user-images.githubusercontent.com/31857308/206913965-abb3225b-1d0b-489f-a276-05844dc0d3a0.png">

